### PR TITLE
Migrate additional source 

### DIFF
--- a/ecs.lobster
+++ b/ecs.lobster
@@ -139,7 +139,7 @@ class shard:
             "@<" + pos[id].x + ", " + pos[id].y + ">",
             "z:" + pos[id].z,
         ]
-        if pos[id].w: "size:" + pos[id].w
+        if pos[id].w: parts.push("size:" + pos[id].w)
         if ren[id].bg != color_clear: parts.push("bg:" + color_to_hex(ren[id].bg))
         if ren[id].glyf != glyph_0:
             parts.push("fg:" + color_to_hex(ren[id].fg))

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -133,12 +133,11 @@ class shard:
     free_ids = []::int
 
     def describe(id:int) -> string:
-        let parts = [
-            "#" + id,
-            entype_str(type[id]),
-            "@<" + pos[id].x + ", " + pos[id].y + ">",
-            "z:" + pos[id].z,
-        ]
+        let parts = vector_reserve(typeof [string], 16)
+        parts.push("#" + id)
+        parts.push(entype_str(type[id]))
+        parts.push("@<" + pos[id].x + ", " + pos[id].y + ">")
+        parts.push("z:" + pos[id].z)
         if pos[id].w: parts.push("size:" + pos[id].w)
         if ren[id].bg != color_clear: parts.push("bg:" + color_to_hex(ren[id].bg))
         if ren[id].glyf != glyph_0:

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -132,9 +132,12 @@ class shard:
 
     free_ids = []::int
 
+    def tag(id:int) -> string:
+        return "#" + id
+
     def describe(id:int) -> string:
         let parts = vector_reserve(typeof [string], 16)
-        parts.push("#" + id)
+        parts.push(tag(id))
         parts.push(entype_str(type[id]))
         parts.push("@<" + pos[id].x + ", " + pos[id].y + ">")
         parts.push("z:" + pos[id].z)

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -514,19 +514,25 @@ class ent_templates:
         return register(tmpl)
 
 class ent_scaffold:
-    loc = xy_0
+    loc = xy_0 // location cell
 
     def at(l:xy_f, body):
-        let base = loc
+        let old_loc = loc
         loc = l
-        if body:
-            body()
-            loc = base
+        body()
+        loc = old_loc
+
+    def at_each(locs, body):
+        let old_loc = loc
+        for(locs) l, i:
+            loc = l
+            body(i)
+        loc = old_loc
 
     def translate(by:xy_f, body):
         at(loc + by, body)
 
-    def each(offsets, body):
+    def translate_each(offsets, body):
         let base = loc
         for(offsets) offset, i:
             loc = base + offset

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -174,12 +174,11 @@ class shard:
         if not type.length: grow() // reserve #0
         return if free_ids.length: reuse() else: grow()
 
-    def create(t:entype, init, post):
+    def create(t:entype, init):
         let id = alloc()
         type[id] = t
         init(id)
         notify_type(id, ent_none, t)
-        if post: post(id)
         return id
 
     def set_type(id:int, t:entype):

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -514,6 +514,8 @@ class ent_templates:
         return register(tmpl)
 
 class ent_scaffold:
+    templates : ent_templates
+
     loc = xy_0            // location cell
     off = xy { 0.5, 0.5 } // sub-cell offset
 

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -482,14 +482,18 @@ class ent_template:
 
     initiative = 0
 
-    spawn_prob = xy_0i
-    spawn_template = 0
+    spawn_template = []::int
+    spawn_prob     = []::xy_i
 
     avatar_helf       = xy_0i
     avatar_stam       = xy_0i
     avatar_gives      = false
     avatar_left_hand  = item_none
     avatar_right_hand = item_none
+
+    def add_spawn_sibling(template_id:int, prob:xy_i):
+        spawn_template.push(template_id)
+        spawn_prob.push(prob)
 
 let ent_0 = ent_template { type: ent_none }
 

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -514,7 +514,8 @@ class ent_templates:
         return register(tmpl)
 
 class ent_scaffold:
-    loc = xy_0 // location cell
+    loc = xy_0            // location cell
+    off = xy { 0.5, 0.5 } // sub-cell offset
 
     def at(l:xy_f, body):
         let old_loc = loc

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -491,6 +491,12 @@ class ent_template:
     avatar_left_hand  = item_none
     avatar_right_hand = item_none
 
+    def dupe():
+        let tmpl = copy(this)
+        tmpl.spawn_template = copy(tmpl.spawn_template)
+        tmpl.spawn_prob = copy(tmpl.spawn_prob)
+        return tmpl
+
     def init_entity(shard:shard, id:int, loc:xy_f):
         shard.pos[id] = spatial { loc.x, loc.y, z, size }
         shard.ren[id] = render { bg, fg, glyph }
@@ -518,9 +524,7 @@ class ent_templates:
         return register(tmpl)
 
     def extend(base_id, body):
-        let tmpl = copy(defs[base_id])
-        tmpl.spawn_template = copy(tmpl.spawn_template)
-        tmpl.spawn_prob = copy(tmpl.spawn_prob)
+        let tmpl = defs[base_id].dupe()
         body(tmpl)
         return register(tmpl)
 

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -491,6 +491,16 @@ class ent_template:
     avatar_left_hand  = item_none
     avatar_right_hand = item_none
 
+    def init_entity(shard:shard, id:int, loc:xy_f):
+        var r = render { bg, fg, glyph }
+        if r.glyf == glyph_0:
+            if       tile != tile_none: r = r.with_glyph(tile_sprite(tile))
+            else: if item != item_none: r = r.with_glyph(item_sprite(item))
+        shard.pos[id] = spatial { loc.x, loc.y, z, size }
+        shard.ren[id] = r
+        if tile != tile_none: shard.tile[id] = tile
+        if item != item_none: shard.item[id] = item
+
     def add_spawn_sibling(template_id:int, prob:xy_i):
         spawn_template.push(template_id)
         spawn_prob.push(prob)
@@ -523,6 +533,9 @@ class ent_scaffold:
 
     loc = xy_0            // location cell
     off = xy { 0.5, 0.5 } // sub-cell offset
+
+    def init_entity(shard:shard, id:int):
+        tmpl.init_entity(shard, id, loc + off)
 
     def use(template_id:int, body):
         let old_tmpl = tmpl

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -519,6 +519,8 @@ class ent_templates:
 
     def extend(base_id, body):
         let tmpl = copy(defs[base_id])
+        tmpl.spawn_template = copy(tmpl.spawn_template)
+        tmpl.spawn_prob = copy(tmpl.spawn_prob)
         body(tmpl)
         return register(tmpl)
 

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -492,12 +492,8 @@ class ent_template:
     avatar_right_hand = item_none
 
     def init_entity(shard:shard, id:int, loc:xy_f):
-        var r = render { bg, fg, glyph }
-        if r.glyf == glyph_0:
-            if       tile != tile_none: r = r.with_glyph(tile_sprite(tile))
-            else: if item != item_none: r = r.with_glyph(item_sprite(item))
         shard.pos[id] = spatial { loc.x, loc.y, z, size }
-        shard.ren[id] = r
+        shard.ren[id] = render { bg, fg, glyph }
         if tile != tile_none: shard.tile[id] = tile
         if item != item_none: shard.item[id] = item
 

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -562,7 +562,7 @@ class ent_scaffold:
 class spawner : system
     ids  = []::int
     prob = []::xy_i
-    tid  = []::int
+    scaf = []::ent_scaffold
 
     def ent_changed(shard, id:int, new:entype, old:entype):
         if new == ent_none:
@@ -570,7 +570,7 @@ class spawner : system
             if n:
                 ids.remove(i, n)
                 prob.remove(i, n)
-                tid.remove(i, n)
+                scaf.remove(i, n)
         return new
 
     def clear_spawn(id:int):
@@ -578,7 +578,7 @@ class spawner : system
         if n:
             ids.remove(i, n)
             prob.remove(i, n)
-            tid.remove(i, n)
+            scaf.remove(i, n)
 
 class spawn_scaffold:
     spawner:spawner
@@ -590,11 +590,11 @@ class spawn_scaffold:
     def prob(x:int, y:int): p = xy_i { x,     y }
     def odds(x:int, y:int): p = xy_i { x, x + y }
 
-    def add_spawn(template_id:int):
-        if template_id != 0 and p.x and p.y:
+    def add_spawn(ctx:ent_scaffold):
+        if ctx.tmpl.type and p.x and p.y:
             spawner.ids.insert(next_spawn_id, id)
             spawner.prob.insert(next_spawn_id, p)
-            spawner.tid.insert(next_spawn_id, template_id)
+            spawner.scaf.insert(next_spawn_id, copy(ctx))
             next_spawn_id++
 
 def add_spawn(this::spawner, id:int, body):

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -116,6 +116,7 @@ let render_0 = render { color_clear, color_clear, glyph_0 }
 class shard:
     // entity type
     type = []::entype
+    name = []::string
 
     // global data relevant to any entity
     pos = []::spatial   // spatial position
@@ -133,7 +134,10 @@ class shard:
     free_ids = []::int
 
     def tag(id:int) -> string:
-        return "#" + id
+        if name[id] != "":
+            return "[" + name[id] + "]#" + id
+        else:
+            return "#" + id
 
     def describe(id:int) -> string:
         let parts = vector_reserve(typeof [string], 16)
@@ -156,6 +160,7 @@ class shard:
         def grow():
             let id = type.length
             type.push(ent_none)
+            name.push("")
             pos.push(spatial_0)
             ren.push(render_0)
             tex.push(nil)
@@ -166,6 +171,7 @@ class shard:
         def reuse():
             let id = free_ids.pop()
             type[id] = ent_none
+            name[id] = ""
             pos[id] = spatial_0
             ren[id] = render_0
             tex[id] = nil
@@ -473,6 +479,7 @@ class minds : system
 
 class ent_template:
     type  : entype
+    name  = ""
     bg    = color_clear
     fg    = color_clear
     glyph = glyph_0
@@ -500,6 +507,7 @@ class ent_template:
         return tmpl
 
     def init_entity(shard:shard, id:int, loc:xy_f):
+        shard.name[id] = name
         shard.pos[id] = spatial { loc.x, loc.y, z, size }
         shard.ren[id] = render { bg, fg, glyph }
         if tile != tile_none: shard.tile[id] = tile

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -613,6 +613,18 @@ class spawn_scaffold:
             spawner.scaf.insert(next_spawn_id, copy(ctx))
             next_spawn_id++
 
+def add_spawns(this::spawner, id:int, ctx:ent_scaffold):
+    let n, spawn_id = ids.binary_search(id)
+    let sp = spawn_scaffold {
+        spawner: this,
+        id: id,
+        next_spawn_id: spawn_id,
+    }
+    for(ctx.tmpl.spawn_template) template_id, i:
+        let p = ctx.tmpl.spawn_prob[i]
+        if p != xy_0i: sp.p = p
+        ctx.use(template_id): sp.add_spawn(ctx)
+
 def add_spawn(this::spawner, id:int, body):
     let n, spawn_id = ids.binary_search(id)
     body(spawn_scaffold {

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -4,6 +4,15 @@ import vec
 import sprites
 import sheets // TODO invert ecs -> sheets dep
 
+def build_string(body):
+    var s = ""
+    body() part:
+        if s.length():
+            s = s + " " + part
+        else:
+            s = s + part
+    return s
+
 def color_to_hex(c:color) -> string: return "#" +
     number_to_string(int(c.red   * 255), 16, 2) +
     number_to_string(int(c.green * 255), 16, 2) +
@@ -142,21 +151,26 @@ class shard:
             return "#" + id
 
     def describe(id:int) -> string:
-        let parts = vector_reserve(typeof [string], 16)
-        parts.push(tag(id))
-        parts.push(entype_str(type[id]))
-        parts.push("@<" + pos[id].x + ", " + pos[id].y + ">")
-        parts.push("z:" + pos[id].z)
-        if pos[id].w: parts.push("size:" + pos[id].w)
-        if ren[id].bg != color_clear: parts.push("bg:" + color_to_hex(ren[id].bg))
+        return build_string() emit:
+            emit(tag(id))
+            describe_intrinsics(id, emit)
+            describe_draw(id, emit)
+
+    def describe_intrinsics(id, emit):
+        emit(entype_str(type[id]))
+        emit("@<" + pos[id].x + ", " + pos[id].y + ">")
+        emit("z:" + pos[id].z)
+        if pos[id].w: emit("size:" + pos[id].w)
+        if tile[id]: emit("" + tile[id])
+        if item[id]: emit("" + item[id])
+
+    def describe_draw(id, emit):
+        if ren[id].bg != color_clear: emit("bg:" + color_to_hex(ren[id].bg))
         if ren[id].glyf != glyph_0:
-            parts.push("fg:" + color_to_hex(ren[id].fg))
-            parts.push("" + ren[id].glyf)
-        if tex[id]: parts.push("tex:" + tex[id])
-        if ksh[id]: parts.push("ksh:" + ksh[id])
-        if tile[id]: parts.push("" + tile[id])
-        if item[id]: parts.push("" + item[id])
-        return parts.concat_string(" ")
+            emit("fg:" + color_to_hex(ren[id].fg))
+            emit("" + ren[id].glyf)
+        if tex[id]: emit("tex:" + tex[id])
+        if ksh[id]: emit("ksh:" + ksh[id])
 
     def alloc() -> int:
         def grow():

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -512,21 +512,18 @@ let ent_0 = ent_template { type: ent_none }
 class ent_templates:
     defs = []::ent_template
 
-    def register(tmpl):
+    def register(tmpl, body):
         if not defs.length: defs.push(ent_0)
         let id = defs.length
         defs.push(tmpl)
+        body(tmpl, id)
         return id
 
     def define(t:entype, body):
-        let tmpl = ent_template { type: t }
-        body(tmpl)
-        return register(tmpl)
+        return register(ent_template { type: t }, body)
 
     def extend(base_id, body):
-        let tmpl = defs[base_id].dupe()
-        body(tmpl)
-        return register(tmpl)
+        return register(defs[base_id].dupe(), body)
 
 class ent_scaffold:
     templates : ent_templates

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -26,7 +26,8 @@ def while_first_index(xs, x, body):
 
 enum_flags entype:
     ent_none = 0    // free entity slot (if no other bits)
-    ent_visible = 1 // scene draw-ables
+    ent_debug = 1   // enable debug logging on this entity
+    ent_visible     // scene draw-ables
     ent_cell        // defines "A space"; e.g. floor entities have this
     ent_body        // has a collide-able body
     ent_mind        // participates in the action system
@@ -35,6 +36,7 @@ enum_flags entype:
 
 def entype_str(t:entype):
     let parts = []
+    if t & ent_debug:   parts.push("debug")
     if t & ent_visible: parts.push("visible")
     if t & ent_cell:    parts.push("cell")
     if t & ent_body:    parts.push("body")

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -121,6 +121,8 @@ class shard:
     pos = []::spatial   // spatial position
     ren = []::render    // colored glyph with an optional background
     tex = []::resource? // render texture overrides any glyph
+    ksh = []::resource? // cached render to texture
+    // TODO drop tex aspect, once we switch fully to graph-structured drawing into ksh
 
     // any associated rule sheet data
     tile = []::tile_entity_id
@@ -143,6 +145,7 @@ class shard:
             parts.push("fg:" + color_to_hex(ren[id].fg))
             parts.push("" + ren[id].glyf)
         if tex[id]: parts.push("tex:" + tex[id])
+        if ksh[id]: parts.push("ksh:" + ksh[id])
         if tile[id]: parts.push("" + tile[id])
         if item[id]: parts.push("" + item[id])
         return parts.concat_string(" ")
@@ -154,6 +157,7 @@ class shard:
             pos.push(spatial_0)
             ren.push(render_0)
             tex.push(nil)
+            ksh.push(nil)
             tile.push(tile_none)
             item.push(item_none)
             return id
@@ -163,6 +167,7 @@ class shard:
             pos[id] = spatial_0
             ren[id] = render_0
             tex[id] = nil
+            ksh[id] = nil
             tile[id] = tile_none
             item[id] = item_none
             return id
@@ -200,6 +205,9 @@ class shard:
             if new != prior:
                 type[id] = new
         return new
+
+    def invalidate(id:int):
+        ksh[id] = nil
 
 //// ancillary component: spatial animation
 

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -104,7 +104,7 @@ struct render:
             gl_color(fg): gl_unit_square()
 
     def with_fg_color(c:color, g:glyph):
-        if c == color_clear: c = color_white
+        if g != glyph_0 and c == color_clear: c = color_white
         return render { bg, c, g }
     def with_fg(c:color): return with_fg_color(c, glyf)
     def with_glyph(g:glyph): return with_fg_color(fg, g)

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -535,11 +535,14 @@ class ent_scaffold:
     def init_entity(shard:shard, id:int):
         tmpl.init_entity(shard, id, loc + off)
 
-    def use(template_id:int, body):
+    def use(template:ent_template, body):
         let old_tmpl = tmpl
-        tmpl = templates.defs[template_id]
+        tmpl = template
         body()
         tmpl = old_tmpl
+
+    def use_id(template_id:int, body):
+        use(templates.defs[template_id], body)
 
     def at(l:xy_f, body):
         let old_loc = loc
@@ -621,7 +624,7 @@ def add_spawns(this::spawner, id:int, ctx:ent_scaffold):
     for(ctx.tmpl.spawn_template) template_id, i:
         let p = ctx.tmpl.spawn_prob[i]
         if p != xy_0i: sp.p = p
-        ctx.use(template_id): sp.add_spawn(ctx)
+        ctx.use_id(template_id): sp.add_spawn(ctx)
 
 def add_spawn(this::spawner, id:int, body):
     let n, spawn_id = ids.binary_search(id)

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -178,7 +178,7 @@ class shard:
         let id = alloc()
         type[id] = t
         init(id)
-        t = notify_type(id, ent_none, t)
+        notify_type(id, ent_none, t)
         if post: post(id)
         return id
 
@@ -188,7 +188,7 @@ class shard:
 
         if t != ent_none:
             type[id] = t
-            t = notify_type(id, old, t)
+            notify_type(id, old, t)
             return
 
         type[id] = ent_none

--- a/ecs.lobster
+++ b/ecs.lobster
@@ -516,8 +516,16 @@ class ent_templates:
 class ent_scaffold:
     templates : ent_templates
 
+    tmpl = ent_template { type : ent_none }
+
     loc = xy_0            // location cell
     off = xy { 0.5, 0.5 } // sub-cell offset
+
+    def use(template_id:int, body):
+        let old_tmpl = tmpl
+        tmpl = templates.defs[template_id]
+        body()
+        tmpl = old_tmpl
 
     def at(l:xy_f, body):
         let old_loc = loc

--- a/ecs_test.lobster
+++ b/ecs_test.lobster
@@ -1,0 +1,21 @@
+import ecs
+import testing
+
+let templates = ent_templates {}
+
+let t_a = templates.define(ent_visible): nil
+let t_b = templates.define(ent_visible): nil
+let t_place = templates.define(ent_visible):
+    _.z    = 1.0
+    _.size = 1.0
+    _.fg   = color_white
+
+run_test("ecs/templates/spawn"):
+    // data should not leak
+    let t_stuff_a = templates.extend(t_place): _.add_spawn_sibling(t_a, xy_i { 1, 2 })
+    let t_stuff_b = templates.extend(t_place): _.add_spawn_sibling(t_b, xy_i { 1, 3 })
+    assert templates.defs[t_stuff_a].spawn_template.length == 1
+    assert templates.defs[t_stuff_b].spawn_template.length == 1
+    assert templates.defs[t_a].spawn_template.length == 0
+    assert templates.defs[t_b].spawn_template.length == 0
+    assert templates.defs[t_place].spawn_template.length == 0

--- a/game.lobster
+++ b/game.lobster
@@ -532,7 +532,7 @@ def elaborate(this::ent_template, ctx:ent_scaffold, chunk:chunk, id:int):
     if this.spawn_prob != xy_0i:
         chunk.spawner.add_spawn(id) sp:
             sp.prob(spawn_prob.x, spawn_prob.y)
-            sp.add_spawn(this.spawn_template)
+            ctx.use(this.spawn_template): sp.add_spawn(ctx)
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
@@ -564,7 +564,9 @@ def spawn(this::spawner, chunk):
 
     def can_spawn(spawn_id) -> bool:
         // TODO other constraints
-        let tmpl = chunk.templates.defs[tid[spawn_id]]
+        let ctx = scaf[spawn_id]
+        // TODO factor out def exists_at(this::ent_scaffold, chunk) -> bool
+        let tmpl = ctx.tmpl
         let there = chunk.bodys_at(pos.cell())
         // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
         if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
@@ -579,8 +581,8 @@ def spawn(this::spawner, chunk):
 
     once_each() id, spawn_id: can_spawn(spawn_id) and should_spawn(spawn_id)
     then id, spawn_id:
-        let ctx = ent_scaffold { templates: chunk.templates }
-        ctx.at(float(pos.cell())): ctx.use(tid[spawn_id]):
+        let ctx = scaf[spawn_id]
+        ctx.at(float(pos.cell())):
             let new_id = ctx.create(chunk)
             print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
 

--- a/game.lobster
+++ b/game.lobster
@@ -260,6 +260,9 @@ class avatars : system
 //// shard integration
 
 class chunk : shard
+    // debug tracing
+    trace = false
+
     // performance timers
     timers = timers{}
 
@@ -580,7 +583,8 @@ def spawn(this::spawner, chunk):
     then id, spawn_id:
         let ctx = scaf[spawn_id]
         ctx.do_spawn(chunk, loc) new_id:
-            print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
+            if chunk.trace:
+                print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
 
 def spawn_items(this::chunk): spawner.spawn(this)
 

--- a/game.lobster
+++ b/game.lobster
@@ -545,11 +545,13 @@ def create_with(this::ent_template, ctx:ent_scaffold, chunk:chunk, body):
 def create(this::ent_template, ctx:ent_scaffold, chunk:chunk):
     return create_with(ctx, chunk): nil
 
-def create(this::ent_templates, id:int, ctx:ent_scaffold, chunk:chunk):
-    return defs[id].create(ctx, chunk)
+def create_with(this::ent_scaffold, chunk:chunk, body):
+    if not tmpl.type:
+        return 0
+    return tmpl.create_with(this, chunk, body)
 
-def create_with(this::ent_templates, id:int, ctx:ent_scaffold, chunk:chunk, body):
-    return defs[id].create_with(ctx, chunk, body)
+def create(this::ent_scaffold, chunk:chunk):
+    return this.create_with(chunk): nil
 
 def spawn(this::spawner, chunk):
     var last_id = -1
@@ -587,9 +589,9 @@ def spawn(this::spawner, chunk):
             templates: chunk.templates,
             loc: float(at.cell()),
         }
-        let template_id = tid[spawn_id]
-        let new_id = chunk.templates.create(template_id, ctx, chunk)
-        print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + template_id)
+        ctx.use(tid[spawn_id]):
+            let new_id = ctx.create(chunk)
+            print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + tid[spawn_id])
 
 def spawn_items(this::chunk): spawner.spawn(this)
 
@@ -716,15 +718,17 @@ def build_world(chunk):
     let tree_fg_base      = color { 0.2,  0.25, 0.1,  1 }
     let tree_fg_variance  = color { 0,    0.5,  0,    0 }
 
-    build.fill_rect(size) x, y:
-        chunk.templates.create_with(floor_template, build, chunk) id:
-            let glyph = dirt.rnd_pick()
-            let bg = floor_bg_base + floor_bg_variance * rnd_float()
-            let fg = if glyph == glyph_0: color_clear else: bg + floor_fg_lift
-            chunk.ren[id] = render { bg, fg, glyph }
-        if x == 0 || y == 0 || x == size-1 || y == size-1:
-            chunk.templates.create_with(trees.rnd_pick(), build, chunk) id:
-                chunk.ren[id] = chunk.ren[id].with_fg(tree_fg_base + tree_fg_variance * rnd_float())
+    build.use(floor_template):
+        build.fill_rect(size) x, y:
+            build.create_with(chunk) id:
+                let glyph = dirt.rnd_pick()
+                let bg = floor_bg_base + floor_bg_variance * rnd_float()
+                let fg = if glyph == glyph_0: color_clear else: bg + floor_fg_lift
+                chunk.ren[id] = render { bg, fg, glyph }
+            if x == 0 || y == 0 || x == size-1 || y == size-1:
+                build.use(trees.rnd_pick()): build.create_with(chunk) id:
+                    chunk.ren[id] = chunk.ren[id].with_fg(tree_fg_base + tree_fg_variance * rnd_float())
+
     let mid = float(floor(size / 2))
     build.translate(xy_f { mid, mid }):
         let l = size / 4
@@ -733,8 +737,8 @@ def build_world(chunk):
             xy_f {  l,  l },
             xy_f {  l, -l },
             xy_f { -l, -l },
-        ]): chunk.templates.create(elements[_], build, chunk)
-        chunk.templates.create(player_template, build, chunk)
+        ]): build.use(elements[_]): build.create(chunk)
+        build.use(player_template): build.create(chunk)
 
 //// usage
 

--- a/game.lobster
+++ b/game.lobster
@@ -537,7 +537,7 @@ def elaborate(this::ent_template, chunk:chunk, id:int):
 def create_with(this::ent_template, ctx:ent_scaffold, chunk:chunk, body):
     assert tile == tile_none or item == item_none // may have associated tile or item sheet data, but not both
     return chunk.create(type) id:
-        place_at(chunk, id, xyz { ctx.loc.x + 0.5, ctx.loc.y + 0.5, z }) // TODO better placement
+        place_at(chunk, id, xyz { ctx.loc.x + ctx.off.x, ctx.loc.y + ctx.off.y, z })
     post id:
         elaborate(chunk, id)
         body(id)

--- a/game.lobster
+++ b/game.lobster
@@ -292,20 +292,22 @@ class chunk : shard
         else:
             ren[id].draw()
 
-    def draw_ent(id, size):
+    def transform_ent(id, size, body):
         let p = pos[id]
         let c = p.xy - p.w / 2
-        gl_translate(c * size): gl_scale(size * p.w):
-            var tx = ksh[id]
-            let tx_size = xy_i { int(size.x), int(size.y) }
-            if !tx or gl_texture_size(tx) != tx_size:
-                tx = render_to_texture(nil, tx_size, false, nil, texture_format_clamp | texture_format_nomipmap):
-                    gl_scale(size): render_ent(id)
-                ksh[id] = tx
-            assert tx // FIXME
-            gl_set_shader("textured")
-            gl_set_primitive_texture(0, tx)
-            gl_color(color_white): gl_unit_square()
+        gl_translate(c * size): gl_scale(size * p.w): body()
+
+    def draw_ent(id, size): transform_ent(id, size):
+        var tx = ksh[id]
+        let tx_size = xy_i { int(size.x), int(size.y) }
+        if !tx or gl_texture_size(tx) != tx_size:
+            tx = render_to_texture(nil, tx_size, false, nil, texture_format_clamp | texture_format_nomipmap):
+                gl_scale(size): render_ent(id)
+            ksh[id] = tx
+        assert tx // FIXME
+        gl_set_shader("textured")
+        gl_set_primitive_texture(0, tx)
+        gl_color(color_white): gl_unit_square()
 
     def can_step():
         return !anims.blocked

--- a/game.lobster
+++ b/game.lobster
@@ -535,11 +535,11 @@ def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
         return 0
     assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
-    return chunk.create(tmpl.type) id:
-        tmpl.place_at(chunk, id, xyz { loc.x + off.x, loc.y + off.x, tmpl.z })
-    post id:
-        tmpl.elaborate(this, chunk, id)
-        body(id, this)
+    let id = chunk.create(tmpl.type) _:
+        tmpl.place_at(chunk, _, xyz { loc.x + off.x, loc.y + off.x, tmpl.z })
+    tmpl.elaborate(this, chunk, id)
+    body(id, this)
+    return id
 
 def create(this::ent_scaffold, chunk:chunk):
     return this.create_with(chunk): nil

--- a/game.lobster
+++ b/game.lobster
@@ -327,6 +327,10 @@ class chunk : shard
             w: a.w,
         }
 
+        if at.length == 1 and at[0] == id:
+            // TODO special case self action?
+            return
+
         anims.animate(id, movement_time) anim:
             anim.blocking = true
             anim.after(0): anim.pos = a

--- a/game.lobster
+++ b/game.lobster
@@ -265,7 +265,7 @@ enum_flags trace:
 
 class chunk : shard
     // debug tracing
-    trace = trace(0)
+    trace = trace(0) // TODO trace_avatar
 
     // performance timers
     timers = timers{}
@@ -668,7 +668,7 @@ let tree_deciduous = templates.define(ent_body | ent_visible):
     _.tile = tile_apple_tree
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 
-let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar | ent_input):
+let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar | ent_input | ent_debug):
     _.name = "player"
     _.z    = 1.0
     _.size = 1.0

--- a/game.lobster
+++ b/game.lobster
@@ -534,22 +534,22 @@ def elaborate(this::ent_template, chunk:chunk, id:int):
             sp.prob(spawn_prob.x, spawn_prob.y)
             sp.add_spawn(this.spawn_template)
 
-def create_with(this::ent_template, chunk:chunk, loc:xy_f, body):
+def create_with(this::ent_template, ctx:ent_scaffold, chunk:chunk, body):
     assert tile == tile_none or item == item_none // may have associated tile or item sheet data, but not both
     return chunk.create(type) id:
-        place_at(chunk, id, xyz { loc.x + 0.5, loc.y + 0.5, z, }) // TODO better placement
+        place_at(chunk, id, xyz { ctx.loc.x + 0.5, ctx.loc.y + 0.5, z }) // TODO better placement
     post id:
         elaborate(chunk, id)
         body(id)
 
-def create(this::ent_template, chunk:chunk, loc:xy_f):
-    return create_with(chunk, loc): nil
+def create(this::ent_template, ctx:ent_scaffold, chunk:chunk):
+    return create_with(ctx, chunk): nil
 
-def create(this::ent_templates, id:int, chunk:chunk, loc:xy_f):
-    return defs[id].create(chunk, loc)
+def create(this::ent_templates, id:int, ctx:ent_scaffold, chunk:chunk):
+    return defs[id].create(ctx, chunk)
 
-def create_with(this::ent_templates, id:int, chunk:chunk, loc:xy_f, body):
-    return defs[id].create_with(chunk, loc, body)
+def create_with(this::ent_templates, id:int, ctx:ent_scaffold, chunk:chunk, body):
+    return defs[id].create_with(ctx, chunk, body)
 
 def spawn(this::spawner, chunk):
     var last_id = -1
@@ -583,9 +583,11 @@ def spawn(this::spawner, chunk):
 
     once_each() id, spawn_id: can_spawn(spawn_id) and should_spawn(spawn_id)
     then id, spawn_id:
-        let loc = float(at.cell())
+        let ctx = ent_scaffold {
+            loc: float(at.cell()),
+        }
         let template_id = tid[spawn_id]
-        let new_id = chunk.templates.create(template_id, chunk, loc)
+        let new_id = chunk.templates.create(template_id, ctx, chunk)
         print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + template_id)
 
 def spawn_items(this::chunk): spawner.spawn(this)
@@ -712,13 +714,13 @@ def build_world(chunk):
     let tree_fg_variance  = color { 0,    0.5,  0,    0 }
 
     build.fill_rect(size) x, y:
-        chunk.templates.create_with(floor_template, chunk, build.loc) id:
+        chunk.templates.create_with(floor_template, build, chunk) id:
             let glyph = dirt.rnd_pick()
             let bg = floor_bg_base + floor_bg_variance * rnd_float()
             let fg = if glyph == glyph_0: color_clear else: bg + floor_fg_lift
             chunk.ren[id] = render { bg, fg, glyph }
         if x == 0 || y == 0 || x == size-1 || y == size-1:
-            chunk.templates.create_with(trees.rnd_pick(), chunk, build.loc) id:
+            chunk.templates.create_with(trees.rnd_pick(), build, chunk) id:
                 chunk.ren[id] = chunk.ren[id].with_fg(tree_fg_base + tree_fg_variance * rnd_float())
     let mid = float(floor(size / 2))
     build.translate(xy_f { mid, mid }):
@@ -728,8 +730,8 @@ def build_world(chunk):
             xy_f {  l,  l },
             xy_f {  l, -l },
             xy_f { -l, -l },
-        ]): chunk.templates.create(elements[_], chunk, build.loc)
-        chunk.templates.create(player_template, chunk, build.loc)
+        ]): chunk.templates.create(elements[_], build, chunk)
+        chunk.templates.create(player_template, build, chunk)
 
 //// usage
 

--- a/game.lobster
+++ b/game.lobster
@@ -617,17 +617,15 @@ let floor_template = templates.define(ent_cell | ent_visible):
     _.z    = 0.0
     _.size = 1.0
 
-let body_template = templates.define(ent_body | ent_visible):
-    _.z    = 1.0
+let tile_template = templates.define(ent_body | ent_visible):
+    _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
 
-let tile_template = templates.extend(body_template):
-    _.z = 0.5
-
-let item_template = templates.extend(body_template):
+let item_template = templates.define(ent_body | ent_visible):
     _.z    = 0.75
     _.size = 1.0 / 3.0
+    _.fg   = color_white
 
 // FIXME tmpl_ prefix to avoid sheet constants ; ideally sheet should own these
 // definitions
@@ -646,8 +644,10 @@ let tree_deciduous = templates.extend(tile_template):
     _.tile = tile_apple_tree
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 
-let mind_template = templates.extend(body_template):
-    _.type = _.type | ent_mind
+let mind_template = templates.define(ent_body | ent_visible | ent_mind):
+    _.z    = 1.0
+    _.size = 1.0
+    _.fg   = color_white
     _.initiative = 1
 
 let avatar_template = templates.extend(mind_template):

--- a/game.lobster
+++ b/game.lobster
@@ -281,6 +281,19 @@ class chunk : shard
     groups    = []::[int]
     hits      = []::[int]
 
+    def draw_ent(id, size):
+        // TODO prerendered tile textures
+        let p = pos[id]
+        let c = p.xy - p.w / 2
+        gl_translate(c * size): gl_scale(size * p.w): // TODO precompute?
+            let tx = tex[id]
+            if tx:
+                gl_set_shader("textured")
+                gl_set_primitive_texture(0, tx)
+                gl_color(color_white): gl_unit_square()
+            else:
+                ren[id].draw()
+
     def can_step():
         return !anims.blocked
 
@@ -439,7 +452,6 @@ class stacked_scene : system
     ids = []::int
     zs  = []::float
     // TODO maybe bucket-by-z rather than full sorting
-    // TODO pre-computed tile
 
     def enter(shard, id):
         let z = shard.pos[id].z
@@ -478,24 +490,10 @@ class stacked_scene : system
         let minc, maxc = bounds(chunk)
         let space_size = float(maxc - minc + 1)
         let side_size  = float(max(1, min(floor(screen_size / space_size))))
-        let cell_size  = xy_f { side_size, side_size }
         let view_rem   = screen_size - space_size * side_size
         gl_translate(float(-minc.xy) * side_size + view_rem / 2):
-            for(ids) id:
-                // TODO precomputed translation
-                // TODO prerendered tile textures
-                let p = chunk.pos[id]
-                let c = p.xy - p.w / 2
-                gl_translate(c * cell_size):
-                    let size = cell_size * p.w
-                    gl_scale(size):
-                        let tex = chunk.tex[id]
-                        if tex:
-                            gl_set_shader("textured")
-                            gl_set_primitive_texture(0, tex)
-                            gl_color(color_white): gl_unit_square()
-                        else:
-                            chunk.ren[id].draw()
+            let cell_size = xy_f { side_size, side_size }
+            for(ids): chunk.draw_ent(_, cell_size)
 
 def create_with(this::ent_template, chunk:chunk, loc:xy_f, body):
     // may have associated tile or item sheet data, but not both

--- a/game.lobster
+++ b/game.lobster
@@ -579,11 +579,8 @@ def spawn(this::spawner, chunk):
 
     once_each() id, spawn_id: can_spawn(spawn_id) and should_spawn(spawn_id)
     then id, spawn_id:
-        let ctx = ent_scaffold {
-            templates: chunk.templates,
-            loc: float(pos.cell()),
-        }
-        ctx.use(tid[spawn_id]):
+        let ctx = ent_scaffold { templates: chunk.templates }
+        ctx.at(float(pos.cell())): ctx.use(tid[spawn_id]):
             let new_id = ctx.create(chunk)
             print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
 

--- a/game.lobster
+++ b/game.lobster
@@ -622,24 +622,12 @@ let body_template = templates.define(ent_body | ent_visible):
     _.size = 1.0
     _.fg   = color_white
 
-let mind_template = templates.extend(body_template):
-    _.type = _.type | ent_mind
-    _.initiative = 1
-
-let avatar_template = templates.extend(mind_template):
-    _.type = _.type | ent_avatar
-    _.initiative = 2
-
 let tile_template = templates.extend(body_template):
     _.z = 0.5
 
 let item_template = templates.extend(body_template):
     _.z    = 0.75
     _.size = 1.0 / 3.0
-
-let player_template = templates.extend(avatar_template):
-    _.type = _.type | ent_input
-    _.initiative = 10
 
 // FIXME tmpl_ prefix to avoid sheet constants ; ideally sheet should own these
 // definitions
@@ -657,6 +645,18 @@ let tree_evergreen = templates.extend(tile_template):
 let tree_deciduous = templates.extend(tile_template):
     _.tile = tile_apple_tree
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
+
+let mind_template = templates.extend(body_template):
+    _.type = _.type | ent_mind
+    _.initiative = 1
+
+let avatar_template = templates.extend(mind_template):
+    _.type = _.type | ent_avatar
+    _.initiative = 2
+
+let player_template = templates.extend(avatar_template):
+    _.type = _.type | ent_input
+    _.initiative = 10
 
 let element_earth = templates.extend(avatar_template):
     _.glyph = item_sprite(item_clover)

--- a/game.lobster
+++ b/game.lobster
@@ -510,31 +510,36 @@ class stacked_scene : system
             let cell_size = xy_f { side_size, side_size }
             for(ids): chunk.draw_ent(_, cell_size)
 
+def place_at(this::ent_template, chunk:chunk, id:int, pos:xyz_f):
+    var r = render { bg, fg, glyph }
+    if r.glyf == glyph_0:
+        if       tile != tile_none: r = r.with_glyph(tile_sprite(tile))
+        else: if item != item_none: r = r.with_glyph(item_sprite(item))
+    chunk.pos[id] = spatial { pos.x, pos.y, pos.z, size }
+    chunk.ren[id] = r
+    if tile != tile_none: chunk.tile[id] = tile
+    if item != item_none: chunk.item[id] = item
+
+def elaborate(this::ent_template, chunk:chunk, id:int):
+    if type & ent_mind:
+        chunk.minds.set_init(id, initiative)
+    if type & ent_avatar: chunk.avatars.with(chunk, id) av:
+        if avatar_helf.y     != 0:         av.helf       = avatar_helf
+        if avatar_stam.y     != 0:         av.stam       = avatar_stam
+        if avatar_gives:                   av.gives      = avatar_gives
+        if avatar_left_hand  != item_none: av.left_hand  = avatar_left_hand
+        if avatar_right_hand != item_none: av.right_hand = avatar_right_hand
+    if this.spawn_prob != xy_0i:
+        chunk.spawner.add_spawn(id) sp:
+            sp.prob(spawn_prob.x, spawn_prob.y)
+            sp.add_spawn(this.spawn_template)
+
 def create_with(this::ent_template, chunk:chunk, loc:xy_f, body):
-    // may have associated tile or item sheet data, but not both
-    assert tile == tile_none or item == item_none
+    assert tile == tile_none or item == item_none // may have associated tile or item sheet data, but not both
     return chunk.create(type) id:
-        var r = render { bg, fg, glyph }
-        if r.glyf == glyph_0:
-            if       tile != tile_none: r = r.with_glyph(tile_sprite(tile))
-            else: if item != item_none: r = r.with_glyph(item_sprite(item))
-        chunk.pos[id] = spatial { loc.x + 0.5, loc.y + 0.5, z, size } // TODO better placement
-        chunk.ren[id] = r
-        if tile != tile_none: chunk.tile[id] = tile
-        if item != item_none: chunk.item[id] = item
+        place_at(chunk, id, xyz { loc.x + 0.5, loc.y + 0.5, z, }) // TODO better placement
     post id:
-        if type & ent_mind:
-            chunk.minds.set_init(id, initiative)
-        if type & ent_avatar: chunk.avatars.with(chunk, id) av:
-            if avatar_helf.y     != 0:         av.helf       = avatar_helf
-            if avatar_stam.y     != 0:         av.stam       = avatar_stam
-            if avatar_gives:                   av.gives      = avatar_gives
-            if avatar_left_hand  != item_none: av.left_hand  = avatar_left_hand
-            if avatar_right_hand != item_none: av.right_hand = avatar_right_hand
-        if this.spawn_prob != xy_0i:
-            chunk.spawner.add_spawn(id) sp:
-                sp.prob(spawn_prob.x, spawn_prob.y)
-                sp.add_spawn(this.spawn_template)
+        elaborate(chunk, id)
         body(id)
 
 def create(this::ent_template, chunk:chunk, loc:xy_f):

--- a/game.lobster
+++ b/game.lobster
@@ -507,16 +507,6 @@ class stacked_scene : system
             let cell_size = xy_f { side_size, side_size }
             for(ids): chunk.draw_ent(_, cell_size)
 
-def init_entity(this::ent_scaffold, chunk:chunk, id:int):
-    var r = render { tmpl.bg, tmpl.fg, tmpl.glyph }
-    if r.glyf == glyph_0:
-        if       tmpl.tile != tile_none: r = r.with_glyph(tile_sprite(tmpl.tile))
-        else: if tmpl.item != item_none: r = r.with_glyph(item_sprite(tmpl.item))
-    chunk.pos[id] = spatial { loc.x + off.x, loc.y + off.x, tmpl.z, tmpl.size }
-    chunk.ren[id] = r
-    if tmpl.tile != tile_none: chunk.tile[id] = tmpl.tile
-    if tmpl.item != item_none: chunk.item[id] = tmpl.item
-
 def build_entity(this::ent_scaffold, chunk:chunk, id:int):
     if tmpl.type & ent_mind:
         chunk.minds.set_init(id, tmpl.initiative)
@@ -537,7 +527,7 @@ def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
         return
     assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
-    let id = chunk.create(tmpl.type) _: init_entity(chunk, _)
+    let id = chunk.create(tmpl.type): this.init_entity(chunk, _)
     build_entity(chunk, id)
     body(id, this)
 

--- a/game.lobster
+++ b/game.lobster
@@ -258,9 +258,13 @@ class avatars : system
 //// shard integration
 
 class chunk : shard
+    // carries game-specific entity templates
     templates = templates 
+
+    // performance timers
     timers = timers{}
 
+    // game-specific entity systems
     spawner = spawner {}
     minds   = minds {}
     bodys   = bodys {}
@@ -269,6 +273,7 @@ class chunk : shard
 
     movement_time = 1.0 / 4
 
+    // scratch data used for action stepping
     actor_ids = []::int
     actions   = []::action
     targets   = []::xy_i

--- a/game.lobster
+++ b/game.lobster
@@ -260,9 +260,6 @@ class avatars : system
 //// shard integration
 
 class chunk : shard
-    // carries game-specific entity templates
-    templates = templates 
-
     // performance timers
     timers = timers{}
 

--- a/game.lobster
+++ b/game.lobster
@@ -524,6 +524,10 @@ def create_with(this::ent_scaffold, chunk:chunk, body):
         return
     assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
     let id = chunk.create(tmpl.type): this.init_entity(chunk, _)
+    let r = chunk.ren[id]
+    if r.glyf == glyph_0:
+        if       tmpl.tile != tile_none: chunk.ren[id] = r.with_glyph(tile_sprite(tmpl.tile))
+        else: if tmpl.item != item_none: chunk.ren[id] = r.with_glyph(item_sprite(tmpl.item))
     build_entity(chunk, id)
     body(id, this)
 

--- a/game.lobster
+++ b/game.lobster
@@ -412,29 +412,29 @@ class chunk : shard
                         // TODO could open offered modal
                         if av.take(offered):
                             other_av.offer_taken()
-                            print("#" + id + " took offered " + offered + " from #" + object_id)
+                            print(this.tag(id) + " took offered " + offered + " from " + this.tag(object_id))
                             return true
                         else:
-                            print("#" + id + " decline offered " + offered + " from #" + object_id)
+                            print(this.tag(id) + " decline offered " + offered + " from " + this.tag(object_id))
                     else:
-                        print("#" + id + " shrug at #" + object_id)
+                        print(this.tag(id) + " shrug at " + this.tag(object_id))
                     return false
                 let tile_id = tile[object_id]
                 let item_id = item[object_id]
                 if item_id != item_none:
                     if av.take(item_id):
                         this.set_type(object_id, ent_none)
-                        print("#" + id + " took " + item_id + " from #" + object_id)
+                        print(this.tag(id) + " took " + item_id + " from " + this.tag(object_id))
                         return true
                     else:
-                        print("#" + id + " pass " + item_id + " from #" + object_id)
+                        print(this.tag(id) + " pass " + item_id + " from " + this.tag(object_id))
                 else: if tile_id != tile_none:
                     // TODO gathering from tiles, climbing onto tiles, entering
                     // vehicle tiles, enter any inner space, ...
-                    print("#" + id + " TODO " + tile_id + " from #" + object_id)
+                    print(this.tag(id) + " TODO " + tile_id + " from " + this.tag(object_id))
                 else:
                     // TODO avatar state (hand items) X object
-                    print("#" + id + " booped an unknown type:" + entype_str(t) + " from #" + object_id)
+                    print(this.tag(id) + " booped an unknown type:" + entype_str(t) + " from " + this.tag(object_id))
                 return false
 
             switch act.act:
@@ -445,7 +445,7 @@ class chunk : shard
                 case action_hand_combine: av.combine_hands()
                 case action_move:
                     if act.dir == xy_0:
-                        print("#" + id + " rest...") // TODO and then...
+                        print(this.tag(id) + " rest...") // TODO and then...
                     else:
                         actor_find_at(actor_id) object_id: boop(object_id)
                         actor_move(id, actor_id)
@@ -584,7 +584,7 @@ def spawn(this::spawner, chunk):
         let ctx = scaf[spawn_id]
         ctx.do_spawn(chunk, loc) new_id:
             if chunk.trace:
-                print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
+                print(chunk.tag(id) + " spawn_id:" + spawn_id + " spawned " + chunk.tag(new_id) + " template:" + ctx.tmpl)
 
 def spawn_items(this::chunk): spawner.spawn(this)
 

--- a/game.lobster
+++ b/game.lobster
@@ -712,7 +712,7 @@ def build_world(chunk):
     let tree_fg_base      = color { 0.2,  0.25, 0.1,  1 }
     let tree_fg_variance  = color { 0,    0.5,  0,    0 }
 
-    build.use(floor_template):
+    build.use_id(floor_template):
         build.fill_rect(size) x, y:
             build.create_with(chunk) id:
                 let glyph = dirt.rnd_pick()
@@ -720,7 +720,7 @@ def build_world(chunk):
                 let fg = if glyph == glyph_0: color_clear else: bg + floor_fg_lift
                 chunk.ren[id] = render { bg, fg, glyph }
             if x == 0 || y == 0 || x == size-1 || y == size-1:
-                build.use(trees.rnd_pick()): build.create_with(chunk) id:
+                build.use_id(trees.rnd_pick()): build.create_with(chunk) id:
                     chunk.ren[id] = chunk.ren[id].with_fg(tree_fg_base + tree_fg_variance * rnd_float())
 
     let mid = float(floor(size / 2))
@@ -731,8 +731,8 @@ def build_world(chunk):
             xy_f {  l,  l },
             xy_f {  l, -l },
             xy_f { -l, -l },
-        ]): build.use(elements[_]): build.create(chunk)
-        build.use(player_template): build.create(chunk)
+        ]): build.use_id(elements[_]): build.create(chunk)
+        build.use_id(player_template): build.create(chunk)
 
 //// usage
 

--- a/game.lobster
+++ b/game.lobster
@@ -533,15 +533,16 @@ def build_entity(this::ent_scaffold, chunk:chunk, id:int):
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
-        return 0
+        return
     assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
     let id = chunk.create(tmpl.type) _: init_entity(chunk, _)
     build_entity(chunk, id)
     body(id, this)
-    return id
 
 def create(this::ent_scaffold, chunk:chunk):
-    return this.create_with(chunk): nil
+    var id = 0
+    this.create_with(chunk) _: id = _
+    return id
 
 def spawn(this::spawner, chunk):
     var last_id = -1

--- a/game.lobster
+++ b/game.lobster
@@ -261,6 +261,7 @@ class avatars : system
 
 enum_flags trace:
     trace_spawn
+    trace_all // all entities, not just ones with ent_debug set
 
 class chunk : shard
     // debug tracing
@@ -288,7 +289,8 @@ class chunk : shard
 
     def should_trace(id, mask):
         if trace & mask:
-            return true
+            if trace & trace_all: return true
+            if type[id] & ent_debug: return true
         return false
 
     def render_ent(id):

--- a/game.lobster
+++ b/game.lobster
@@ -250,7 +250,7 @@ class avatars : system
         if (old ^ new) & ent_avatar:
             if       new & ent_avatar: this.enter(shard, id, new)
             else: if old & ent_avatar: this.exit(shard, id)
-        else: if (old ^ new) & ent_input:
+        else: if shard.type[id] & ent_avatar and (old ^ new) & ent_input:
             let show = if new & ent_input: true else: false
             this.with(shard, id) av:
                 av.show_hearts = show

--- a/game.lobster
+++ b/game.lobster
@@ -723,7 +723,7 @@ def build_world(chunk):
     let mid = float(floor(size / 2))
     build.translate(xy_f { mid, mid }):
         let l = size / 4
-        build.each([
+        build.translate_each([
             xy_f { -l,  l },
             xy_f {  l,  l },
             xy_f {  l, -l },

--- a/game.lobster
+++ b/game.lobster
@@ -35,6 +35,27 @@ import ecs
 
 */
 
+def print_list(title, level, body):
+    var first = true
+    var last = ""
+    var indent = repeat_string(" ", 2*level)
+    body(level) item:
+        if last != "":
+            if first:
+                first = false
+                print(indent + "- " + title + ":")
+                level++
+                indent = repeat_string(" ", 2*level)
+            print(indent + "- " + last)
+        last = item
+    if first:
+        if last == "":
+            print(indent + "- " + title + ": --none--")
+        else:
+            print(indent + "- " + title + ": " + last)
+    else: if last != "":
+        print(indent + "- " + last)
+
 // TODO eject data templates into separate module
 let templates = ent_templates {}
 

--- a/game.lobster
+++ b/game.lobster
@@ -617,11 +617,6 @@ let floor_template = templates.define(ent_cell | ent_visible):
     _.z    = 0.0
     _.size = 1.0
 
-let tile_template = templates.define(ent_body | ent_visible):
-    _.z    = 0.5
-    _.size = 1.0
-    _.fg   = color_white
-
 let item_template = templates.define(ent_body | ent_visible):
     _.z    = 0.75
     _.size = 1.0 / 3.0
@@ -636,11 +631,17 @@ let tmpl_item_pine_apple = templates.extend(item_template):
 let tmpl_item_apple = templates.extend(item_template):
     _.item = item_apple
 
-let tree_evergreen = templates.extend(tile_template):
+let tree_evergreen = templates.define(ent_body | ent_visible):
+    _.z    = 0.5
+    _.size = 1.0
+    _.fg   = color_white
     _.tile = tile_pine_tree
     _.add_spawn_sibling(tmpl_item_pine_apple, xy_i { 5, 1000 })
 
-let tree_deciduous = templates.extend(tile_template):
+let tree_deciduous = templates.define(ent_body | ent_visible):
+    _.z    = 0.5
+    _.size = 1.0
+    _.fg   = color_white
     _.tile = tile_apple_tree
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 

--- a/game.lobster
+++ b/game.lobster
@@ -585,7 +585,7 @@ def spawn(this::spawner, chunk):
         }
         ctx.use(tid[spawn_id]):
             let new_id = ctx.create(chunk)
-            print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + tid[spawn_id])
+            print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
 
 def spawn_items(this::chunk): spawner.spawn(this)
 

--- a/game.lobster
+++ b/game.lobster
@@ -259,9 +259,12 @@ class avatars : system
 
 //// shard integration
 
+enum_flags trace:
+    trace_spawn
+
 class chunk : shard
     // debug tracing
-    trace = false
+    trace = trace(0)
 
     // performance timers
     timers = timers{}
@@ -282,6 +285,11 @@ class chunk : shard
     group_ids = []::int
     groups    = []::[int]
     hits      = []::[int]
+
+    def should_trace(id, mask):
+        if trace & mask:
+            return true
+        return false
 
     def render_ent(id):
         let tx = tex[id]
@@ -583,7 +591,7 @@ def spawn(this::spawner, chunk):
     then id, spawn_id:
         let ctx = scaf[spawn_id]
         ctx.do_spawn(chunk, loc) new_id:
-            if chunk.trace:
+            if chunk.should_trace(id, trace_spawn):
                 print(chunk.tag(id) + " spawn_id:" + spawn_id + " spawned " + chunk.tag(new_id) + " template:" + ctx.tmpl)
 
 def spawn_items(this::chunk): spawner.spawn(this)

--- a/game.lobster
+++ b/game.lobster
@@ -507,37 +507,36 @@ class stacked_scene : system
             let cell_size = xy_f { side_size, side_size }
             for(ids): chunk.draw_ent(_, cell_size)
 
-def place_at(this::ent_template, chunk:chunk, id:int, pos:xyz_f):
-    var r = render { bg, fg, glyph }
+def init_entity(this::ent_scaffold, chunk:chunk, id:int):
+    var r = render { tmpl.bg, tmpl.fg, tmpl.glyph }
     if r.glyf == glyph_0:
-        if       tile != tile_none: r = r.with_glyph(tile_sprite(tile))
-        else: if item != item_none: r = r.with_glyph(item_sprite(item))
-    chunk.pos[id] = spatial { pos.x, pos.y, pos.z, size }
+        if       tmpl.tile != tile_none: r = r.with_glyph(tile_sprite(tmpl.tile))
+        else: if tmpl.item != item_none: r = r.with_glyph(item_sprite(tmpl.item))
+    chunk.pos[id] = spatial { loc.x + off.x, loc.y + off.x, tmpl.z, tmpl.size }
     chunk.ren[id] = r
-    if tile != tile_none: chunk.tile[id] = tile
-    if item != item_none: chunk.item[id] = item
+    if tmpl.tile != tile_none: chunk.tile[id] = tmpl.tile
+    if tmpl.item != item_none: chunk.item[id] = tmpl.item
 
-def elaborate(this::ent_template, ctx:ent_scaffold, chunk:chunk, id:int):
-    if type & ent_mind:
-        chunk.minds.set_init(id, initiative)
-    if type & ent_avatar: chunk.avatars.with(chunk, id) av:
-        if avatar_helf.y     != 0:         av.helf       = avatar_helf
-        if avatar_stam.y     != 0:         av.stam       = avatar_stam
-        if avatar_gives:                   av.gives      = avatar_gives
-        if avatar_left_hand  != item_none: av.left_hand  = avatar_left_hand
-        if avatar_right_hand != item_none: av.right_hand = avatar_right_hand
-    if this.spawn_prob != xy_0i:
+def build_entity(this::ent_scaffold, chunk:chunk, id:int):
+    if tmpl.type & ent_mind:
+        chunk.minds.set_init(id, tmpl.initiative)
+    if tmpl.type & ent_avatar: chunk.avatars.with(chunk, id) av:
+        if tmpl.avatar_helf.y     != 0:         av.helf       = tmpl.avatar_helf
+        if tmpl.avatar_stam.y     != 0:         av.stam       = tmpl.avatar_stam
+        if tmpl.avatar_gives:                   av.gives      = tmpl.avatar_gives
+        if tmpl.avatar_left_hand  != item_none: av.left_hand  = tmpl.avatar_left_hand
+        if tmpl.avatar_right_hand != item_none: av.right_hand = tmpl.avatar_right_hand
+    if tmpl.spawn_prob != xy_0i:
         chunk.spawner.add_spawn(id) sp:
-            sp.prob(spawn_prob.x, spawn_prob.y)
-            ctx.use(this.spawn_template): sp.add_spawn(ctx)
+            sp.prob(tmpl.spawn_prob.x, tmpl.spawn_prob.y)
+            use(tmpl.spawn_template): sp.add_spawn(this)
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
         return 0
     assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
-    let id = chunk.create(tmpl.type) _:
-        tmpl.place_at(chunk, _, xyz { loc.x + off.x, loc.y + off.x, tmpl.z })
-    tmpl.elaborate(this, chunk, id)
+    let id = chunk.create(tmpl.type) _: init_entity(chunk, _)
+    build_entity(chunk, id)
     body(id, this)
     return id
 

--- a/game.lobster
+++ b/game.lobster
@@ -526,10 +526,12 @@ def build_entity(this::ent_scaffold, chunk:chunk, id:int):
         if tmpl.avatar_gives:                   av.gives      = tmpl.avatar_gives
         if tmpl.avatar_left_hand  != item_none: av.left_hand  = tmpl.avatar_left_hand
         if tmpl.avatar_right_hand != item_none: av.right_hand = tmpl.avatar_right_hand
-    if tmpl.spawn_prob != xy_0i:
+    if tmpl.spawn_template.length:
         chunk.spawner.add_spawn(id) sp:
-            sp.prob(tmpl.spawn_prob.x, tmpl.spawn_prob.y)
-            use(tmpl.spawn_template): sp.add_spawn(this)
+            for(tmpl.spawn_template) template_id, i:
+                let prob = tmpl.spawn_prob[i]
+                if prob != xy_0i: sp.p = prob
+                use(template_id): sp.add_spawn(this)
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
@@ -543,6 +545,18 @@ def create(this::ent_scaffold, chunk:chunk):
     var id = 0
     this.create_with(chunk) _: id = _
     return id
+
+def may_spawn(this::ent_scaffold, chunk:chunk, l:xy_f):
+    let there = chunk.bodys_at(int(l))
+    // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
+    if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
+    if tmpl.item != item_none: return !exists(there): chunk.item[_] == tmpl.item
+    if tmpl.type & ent_body: return !exists(there): chunk.type[_] & ent_body
+    return true
+
+def do_spawn(this::ent_scaffold, chunk:chunk, l:xy_f, body):
+    at(l):
+        create_with(chunk, body)
 
 def spawn(this::spawner, chunk):
     var last_id = -1
@@ -560,16 +574,8 @@ def spawn(this::spawner, chunk):
                 did = true
 
     def can_spawn(spawn_id) -> bool:
-        // TODO other constraints
         let ctx = scaf[spawn_id]
-        // TODO factor out def exists_at(this::ent_scaffold, chunk) -> bool
-        let tmpl = ctx.tmpl
-        let there = chunk.bodys_at(int(loc))
-        // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
-        if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
-        if tmpl.item != item_none: return !exists(there): chunk.item[_] == tmpl.item
-        if tmpl.type & ent_body: return !exists(there): chunk.type[_] & ent_body
-        return true
+        return ctx.may_spawn(chunk, loc)
 
     def should_spawn(spawn_id) -> bool:
         // TODO other trigger modes or distributions?
@@ -579,8 +585,7 @@ def spawn(this::spawner, chunk):
     once_each() id, spawn_id: can_spawn(spawn_id) and should_spawn(spawn_id)
     then id, spawn_id:
         let ctx = scaf[spawn_id]
-        ctx.at(loc):
-            let new_id = ctx.create(chunk)
+        ctx.do_spawn(chunk, loc) new_id:
             print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
 
 def spawn_items(this::chunk): spawner.spawn(this)
@@ -657,13 +662,11 @@ let tmpl_item_apple = templates.extend(item_template):
 
 let tree_evergreen = templates.extend(tile_template):
     _.tile = tile_pine_tree
-    _.spawn_prob = xy_i { 5, 1000 }
-    _.spawn_template = tmpl_item_pine_apple
+    _.add_spawn_sibling(tmpl_item_pine_apple, xy_i { 5, 1000 })
 
 let tree_deciduous = templates.extend(tile_template):
     _.tile = tile_apple_tree
-    _.spawn_prob = xy_i { 5, 1000 }
-    _.spawn_template = tmpl_item_apple
+    _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 
 let element_earth = templates.extend(avatar_template):
     _.glyph = item_sprite(item_clover)

--- a/game.lobster
+++ b/game.lobster
@@ -584,6 +584,7 @@ def spawn(this::spawner, chunk):
     once_each() id, spawn_id: can_spawn(spawn_id) and should_spawn(spawn_id)
     then id, spawn_id:
         let ctx = ent_scaffold {
+            templates: chunk.templates,
             loc: float(at.cell()),
         }
         let template_id = tid[spawn_id]
@@ -695,7 +696,9 @@ let element_air = templates.extend(char_template):
 
 def build_world(chunk):
     let size = 12
-    let build = ent_scaffold {}
+    let build = ent_scaffold {
+        templates : templates
+    }
 
     let dirt = [
         glyph_0, glyph_0, uniblock(0x2591), // ░

--- a/game.lobster
+++ b/game.lobster
@@ -549,14 +549,14 @@ def create(this::ent_scaffold, chunk:chunk):
 
 def spawn(this::spawner, chunk):
     var last_id = -1
-    var at = spatial_0
+    var pos = spatial_0
     var did = false
 
     def once_each(when, then):
         for(ids) id, spawn_id:
             if id != last_id:
                 last_id = id
-                at = chunk.pos[id]
+                pos = chunk.pos[id]
                 did = false
             if not did and when(id, spawn_id):
                 then(id, spawn_id)
@@ -565,7 +565,7 @@ def spawn(this::spawner, chunk):
     def can_spawn(spawn_id) -> bool:
         // TODO other constraints
         let tmpl = chunk.templates.defs[tid[spawn_id]]
-        let there = chunk.bodys_at(at.cell())
+        let there = chunk.bodys_at(pos.cell())
         // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
         if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
         if tmpl.item != item_none: return !exists(there): chunk.item[_] == tmpl.item
@@ -581,7 +581,7 @@ def spawn(this::spawner, chunk):
     then id, spawn_id:
         let ctx = ent_scaffold {
             templates: chunk.templates,
-            loc: float(at.cell()),
+            loc: float(pos.cell()),
         }
         ctx.use(tid[spawn_id]):
             let new_id = ctx.create(chunk)

--- a/game.lobster
+++ b/game.lobster
@@ -546,14 +546,14 @@ def create(this::ent_scaffold, chunk:chunk):
 
 def spawn(this::spawner, chunk):
     var last_id = -1
-    var pos = spatial_0
+    var loc = xy_0
     var did = false
 
     def once_each(when, then):
         for(ids) id, spawn_id:
             if id != last_id:
                 last_id = id
-                pos = chunk.pos[id]
+                loc = float(chunk.pos[id].cell())
                 did = false
             if not did and when(id, spawn_id):
                 then(id, spawn_id)
@@ -564,7 +564,7 @@ def spawn(this::spawner, chunk):
         let ctx = scaf[spawn_id]
         // TODO factor out def exists_at(this::ent_scaffold, chunk) -> bool
         let tmpl = ctx.tmpl
-        let there = chunk.bodys_at(pos.cell())
+        let there = chunk.bodys_at(int(loc))
         // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
         if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
         if tmpl.item != item_none: return !exists(there): chunk.item[_] == tmpl.item
@@ -579,7 +579,7 @@ def spawn(this::spawner, chunk):
     once_each() id, spawn_id: can_spawn(spawn_id) and should_spawn(spawn_id)
     then id, spawn_id:
         let ctx = scaf[spawn_id]
-        ctx.at(float(pos.cell())):
+        ctx.at(loc):
             let new_id = ctx.create(chunk)
             print("#" + id + " spawn_id:" + spawn_id + " spawned #" + new_id + " template:" + ctx.tmpl)
 

--- a/game.lobster
+++ b/game.lobster
@@ -622,21 +622,32 @@ let floor_template = templates.define(ent_cell | ent_visible):
     _.z    = 0.0
     _.size = 1.0
 
-let tile_template = templates.define(ent_body | ent_visible):
-    _.z    = 0.5
+let body_template = templates.define(ent_body | ent_visible):
+    _.z    = 1.0
     _.size = 1.0
+    _.fg   = color_white
 
-let item_template = templates.define(ent_body | ent_visible):
+let mind_template = templates.extend(body_template):
+    _.type = _.type | ent_mind
+    _.initiative = 1
+
+let avatar_template = templates.extend(mind_template):
+    _.type = _.type | ent_avatar
+    _.initiative = 2
+
+let tile_template = templates.extend(body_template):
+    _.z = 0.5
+
+let item_template = templates.extend(body_template):
     _.z    = 0.75
     _.size = 1.0 / 3.0
 
-let char_template = templates.define(ent_body | ent_visible | ent_avatar | ent_mind):
-    _.z    = 1.0
-    _.size = 1.0
-
-let player_template = templates.extend(char_template):
+let player_template = templates.extend(avatar_template):
     _.type = _.type | ent_input
     _.initiative = 10
+
+// FIXME tmpl_ prefix to avoid sheet constants ; ideally sheet should own these
+// definitions
 
 let tmpl_item_pine_apple = templates.extend(item_template):
     _.item = item_pine_apple
@@ -654,7 +665,7 @@ let tree_deciduous = templates.extend(tile_template):
     _.spawn_prob = xy_i { 5, 1000 }
     _.spawn_template = tmpl_item_apple
 
-let element_earth = templates.extend(char_template):
+let element_earth = templates.extend(avatar_template):
     _.glyph = item_sprite(item_clover)
     _.fg = color_dark_green
     _.initiative = 3
@@ -662,7 +673,7 @@ let element_earth = templates.extend(char_template):
     _.avatar_left_hand = item_clover
     _.avatar_right_hand = item_clover
 
-let element_water = templates.extend(char_template):
+let element_water = templates.extend(avatar_template):
     _.glyph = item_sprite(item_water)
     _.fg = color_teal
     _.initiative = 4
@@ -670,7 +681,7 @@ let element_water = templates.extend(char_template):
     _.avatar_left_hand = item_water
     _.avatar_right_hand = item_water
 
-let element_fire = templates.extend(char_template):
+let element_fire = templates.extend(avatar_template):
     _.glyph = item_sprite(item_fire)
     _.fg = color_orange
     _.initiative = 6
@@ -678,7 +689,7 @@ let element_fire = templates.extend(char_template):
     _.avatar_left_hand = item_fire
     _.avatar_right_hand = item_fire
 
-let element_air = templates.extend(char_template):
+let element_air = templates.extend(avatar_template):
     _.glyph = item_sprite(item_wind)
     _.fg = color_cyan
     _.initiative = 5

--- a/game.lobster
+++ b/game.lobster
@@ -644,17 +644,15 @@ let tree_deciduous = templates.extend(tile_template):
     _.tile = tile_apple_tree
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 
-let avatar_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar | ent_input):
     _.z    = 1.0
     _.size = 1.0
     _.fg   = color_white
-    _.initiative = 2
-
-let player_template = templates.extend(avatar_template):
-    _.type = _.type | ent_input
     _.initiative = 10
 
-let element_earth = templates.extend(avatar_template):
+let element_earth = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.z    = 1.0
+    _.size = 1.0
     _.glyph = item_sprite(item_clover)
     _.fg = color_dark_green
     _.initiative = 3
@@ -662,7 +660,9 @@ let element_earth = templates.extend(avatar_template):
     _.avatar_left_hand = item_clover
     _.avatar_right_hand = item_clover
 
-let element_water = templates.extend(avatar_template):
+let element_water = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.z    = 1.0
+    _.size = 1.0
     _.glyph = item_sprite(item_water)
     _.fg = color_teal
     _.initiative = 4
@@ -670,7 +670,9 @@ let element_water = templates.extend(avatar_template):
     _.avatar_left_hand = item_water
     _.avatar_right_hand = item_water
 
-let element_fire = templates.extend(avatar_template):
+let element_fire = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.z    = 1.0
+    _.size = 1.0
     _.glyph = item_sprite(item_fire)
     _.fg = color_orange
     _.initiative = 6
@@ -678,7 +680,9 @@ let element_fire = templates.extend(avatar_template):
     _.avatar_left_hand = item_fire
     _.avatar_right_hand = item_fire
 
-let element_air = templates.extend(avatar_template):
+let element_air = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.z    = 1.0
+    _.size = 1.0
     _.glyph = item_sprite(item_wind)
     _.fg = color_cyan
     _.initiative = 5

--- a/game.lobster
+++ b/game.lobster
@@ -208,6 +208,7 @@ class avatars : system
             gl_scale(float(res)):
                 av.draw_tile()
         av.retex = false
+        shard.invalidate(id)
 
     def update_any(shard):
         for(avatars) av, avatar_id: if av.retex:
@@ -243,6 +244,7 @@ class avatars : system
             ids.remove(avatar_id, n)
             avatars.remove(avatar_id, n)
             shard.tex[id] = nil
+            shard.invalidate(id)
 
     def ent_changed(shard, id:int, new:entype, old:entype):
         if (old ^ new) & ent_avatar:
@@ -281,18 +283,29 @@ class chunk : shard
     groups    = []::[int]
     hits      = []::[int]
 
+    def render_ent(id):
+        let tx = tex[id]
+        if tx:
+            gl_set_shader("textured")
+            gl_set_primitive_texture(0, tx)
+            gl_color(color_white): gl_unit_square()
+        else:
+            ren[id].draw()
+
     def draw_ent(id, size):
-        // TODO prerendered tile textures
         let p = pos[id]
         let c = p.xy - p.w / 2
-        gl_translate(c * size): gl_scale(size * p.w): // TODO precompute?
-            let tx = tex[id]
-            if tx:
-                gl_set_shader("textured")
-                gl_set_primitive_texture(0, tx)
-                gl_color(color_white): gl_unit_square()
-            else:
-                ren[id].draw()
+        gl_translate(c * size): gl_scale(size * p.w):
+            var tx = ksh[id]
+            let tx_size = xy_i { int(size.x), int(size.y) }
+            if !tx or gl_texture_size(tx) != tx_size:
+                tx = render_to_texture(nil, tx_size, false, nil, texture_format_clamp | texture_format_nomipmap):
+                    gl_scale(size): render_ent(id)
+                ksh[id] = tx
+            assert tx // FIXME
+            gl_set_shader("textured")
+            gl_set_primitive_texture(0, tx)
+            gl_color(color_white): gl_unit_square()
 
     def can_step():
         return !anims.blocked

--- a/game.lobster
+++ b/game.lobster
@@ -644,14 +644,10 @@ let tree_deciduous = templates.extend(tile_template):
     _.tile = tile_apple_tree
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 
-let mind_template = templates.define(ent_body | ent_visible | ent_mind):
+let avatar_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
     _.z    = 1.0
     _.size = 1.0
     _.fg   = color_white
-    _.initiative = 1
-
-let avatar_template = templates.extend(mind_template):
-    _.type = _.type | ent_avatar
     _.initiative = 2
 
 let player_template = templates.extend(avatar_template):

--- a/game.lobster
+++ b/game.lobster
@@ -617,18 +617,19 @@ let floor_template = templates.define(ent_cell | ent_visible):
     _.z    = 0.0
     _.size = 1.0
 
-let item_template = templates.define(ent_body | ent_visible):
-    _.z    = 0.75
-    _.size = 1.0 / 3.0
-    _.fg   = color_white
-
 // FIXME tmpl_ prefix to avoid sheet constants ; ideally sheet should own these
 // definitions
 
-let tmpl_item_pine_apple = templates.extend(item_template):
+let tmpl_item_pine_apple = templates.define(ent_body | ent_visible):
+    _.z    = 0.75
+    _.size = 1.0 / 3.0
+    _.fg   = color_white
     _.item = item_pine_apple
 
-let tmpl_item_apple = templates.extend(item_template):
+let tmpl_item_apple = templates.define(ent_body | ent_visible):
+    _.z    = 0.75
+    _.size = 1.0 / 3.0
+    _.fg   = color_white
     _.item = item_apple
 
 let tree_evergreen = templates.define(ent_body | ent_visible):

--- a/game.lobster
+++ b/game.lobster
@@ -534,21 +534,15 @@ def elaborate(this::ent_template, chunk:chunk, id:int):
             sp.prob(spawn_prob.x, spawn_prob.y)
             sp.add_spawn(this.spawn_template)
 
-def create_with(this::ent_template, ctx:ent_scaffold, chunk:chunk, body):
-    assert tile == tile_none or item == item_none // may have associated tile or item sheet data, but not both
-    return chunk.create(type) id:
-        place_at(chunk, id, xyz { ctx.loc.x + ctx.off.x, ctx.loc.y + ctx.off.y, z })
-    post id:
-        elaborate(chunk, id)
-        body(id)
-
-def create(this::ent_template, ctx:ent_scaffold, chunk:chunk):
-    return create_with(ctx, chunk): nil
-
 def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
         return 0
-    return tmpl.create_with(this, chunk, body)
+    assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
+    return chunk.create(tmpl.type) id:
+        tmpl.place_at(chunk, id, xyz { loc.x + off.x, loc.y + off.x, tmpl.z })
+    post id:
+        tmpl.elaborate(chunk, id)
+        body(id, this)
 
 def create(this::ent_scaffold, chunk:chunk):
     return this.create_with(chunk): nil

--- a/game.lobster
+++ b/game.lobster
@@ -520,7 +520,7 @@ def place_at(this::ent_template, chunk:chunk, id:int, pos:xyz_f):
     if tile != tile_none: chunk.tile[id] = tile
     if item != item_none: chunk.item[id] = item
 
-def elaborate(this::ent_template, chunk:chunk, id:int):
+def elaborate(this::ent_template, ctx:ent_scaffold, chunk:chunk, id:int):
     if type & ent_mind:
         chunk.minds.set_init(id, initiative)
     if type & ent_avatar: chunk.avatars.with(chunk, id) av:
@@ -541,7 +541,7 @@ def create_with(this::ent_scaffold, chunk:chunk, body):
     return chunk.create(tmpl.type) id:
         tmpl.place_at(chunk, id, xyz { loc.x + off.x, loc.y + off.x, tmpl.z })
     post id:
-        tmpl.elaborate(chunk, id)
+        tmpl.elaborate(this, chunk, id)
         body(id, this)
 
 def create(this::ent_scaffold, chunk:chunk):

--- a/game.lobster
+++ b/game.lobster
@@ -517,11 +517,7 @@ def build_entity(this::ent_scaffold, chunk:chunk, id:int):
         if tmpl.avatar_left_hand  != item_none: av.left_hand  = tmpl.avatar_left_hand
         if tmpl.avatar_right_hand != item_none: av.right_hand = tmpl.avatar_right_hand
     if tmpl.spawn_template.length:
-        chunk.spawner.add_spawn(id) sp:
-            for(tmpl.spawn_template) template_id, i:
-                let prob = tmpl.spawn_prob[i]
-                if prob != xy_0i: sp.p = prob
-                use(template_id): sp.add_spawn(this)
+        chunk.spawner.add_spawns(id, this)
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:

--- a/game.lobster
+++ b/game.lobster
@@ -629,18 +629,21 @@ let floor_template = templates.define(ent_cell | ent_visible):
 // definitions
 
 let tmpl_item_pine_apple = templates.define(ent_body | ent_visible):
+    _.name = "pineapple"
     _.z    = 0.75
     _.size = 1.0 / 3.0
     _.fg   = color_white
     _.item = item_pine_apple
 
 let tmpl_item_apple = templates.define(ent_body | ent_visible):
+    _.name = "apple"
     _.z    = 0.75
     _.size = 1.0 / 3.0
     _.fg   = color_white
     _.item = item_apple
 
 let tree_evergreen = templates.define(ent_body | ent_visible):
+    _.name = "evergreen tree"
     _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
@@ -648,6 +651,7 @@ let tree_evergreen = templates.define(ent_body | ent_visible):
     _.add_spawn_sibling(tmpl_item_pine_apple, xy_i { 5, 1000 })
 
 let tree_deciduous = templates.define(ent_body | ent_visible):
+    _.name = "deciduous tree"
     _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
@@ -655,12 +659,14 @@ let tree_deciduous = templates.define(ent_body | ent_visible):
     _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
 
 let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar | ent_input):
+    _.name = "player"
     _.z    = 1.0
     _.size = 1.0
     _.fg   = color_white
     _.initiative = 10
 
 let element_earth = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.name = "earth elemental"
     _.z    = 1.0
     _.size = 1.0
     _.glyph = item_sprite(item_clover)
@@ -671,6 +677,7 @@ let element_earth = templates.define(ent_body | ent_visible | ent_mind | ent_ava
     _.avatar_right_hand = item_clover
 
 let element_water = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.name = "water elemental"
     _.z    = 1.0
     _.size = 1.0
     _.glyph = item_sprite(item_water)
@@ -681,6 +688,7 @@ let element_water = templates.define(ent_body | ent_visible | ent_mind | ent_ava
     _.avatar_right_hand = item_water
 
 let element_fire = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.name = "fire elemental"
     _.z    = 1.0
     _.size = 1.0
     _.glyph = item_sprite(item_fire)
@@ -691,6 +699,7 @@ let element_fire = templates.define(ent_body | ent_visible | ent_mind | ent_avat
     _.avatar_right_hand = item_fire
 
 let element_air = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
+    _.name = "air elemental"
     _.z    = 1.0
     _.size = 1.0
     _.glyph = item_sprite(item_wind)


### PR DESCRIPTION
#12 only migrate lobster-forked sources present in kris's fork, missing some sporadic work over the last 3 months from my fork.

This mostly contains prep work ahead of upcoming work to add graph structure to shard, in lieu of the bespoke "avatar" system previously used for game mechanics:
- a revamp to the entity template/scaffold building system
- an area and entity-flag based debug tracing system
- refactored entity drawing and rendering

The data generation pipeline has not yet been modified to take advantage of the new template system's potential, an exercised planned for once we get to the other side of the graph refactor.