### PR TITLE
Leverage new ECS graph structure in the mechanical demo

### DIFF
--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -42,6 +42,8 @@ enum_flags entype:
     ent_body        // has a collide-able body
     ent_mind        // participates in the action system
     ent_input       // receives player input
+    ent_holds       // can contain other entities (up to cap)
+    ent_acts        // used to act upon the world
     ent_avatar      // has avatar
 
 def entype_str(t:entype):
@@ -54,6 +56,8 @@ def entype_str(t:entype):
     if t & ent_mind:    parts.push("mind")
     if t & ent_input:   parts.push("input")
     if t & ent_avatar:  parts.push("avatar")
+    if t & ent_holds:  parts.push("holds")
+    if t & ent_acts:  parts.push("acts")
     return parts.concat_string("|")
 
 enum entrel:
@@ -158,7 +162,8 @@ class shard:
     first = []::int    // id of first child
 
     // global data relevant to any entity
-    pos = []::spatial   // spatial position
+    pos = []::spatial   // outer spatial position and size
+    cap = []::xy_f      // inner spatial capacity
     ren = []::render    // colored glyph with an optional background
     tex = []::resource? // render texture overrides any glyph
     ksh = []::resource? // cached render to texture
@@ -202,6 +207,7 @@ class shard:
         if ksh[id]: emit("ksh:" + ksh[id])
 
     def describe_graph(id, emit):
+        if cap[id] != xy_0: emit("cap:" + cap[id])
         if par[id]:
             emit("par" + tag(par[id]))
             emit("rel:" + rel[id])
@@ -220,6 +226,7 @@ class shard:
             prev.push(0)
             first.push(0)
             pos.push(spatial_0)
+            cap.push(xy_0)
             ren.push(render_0)
             tex.push(nil)
             ksh.push(nil)
@@ -236,6 +243,7 @@ class shard:
             prev[id] = 0
             first[id] = 0
             pos[id] = spatial_0
+            cap[id] = xy_0
             ren[id] = render_0
             tex[id] = nil
             ksh[id] = nil
@@ -576,7 +584,7 @@ def animate(this::anims, id:int, over:float, body):
         time:  over,
     }.with(body)
 
-//// ancillary component: bodys collide
+//// ancillary component: root bodys collide
 
 class bodys : system
     ids:[int] = []
@@ -588,10 +596,16 @@ class bodys : system
         ids.remove(body_id, 1)
 
     def ent_changed(shard, id:int, new:entype, old:entype):
-        if (old ^ new) & ent_body:
+        if shard.par[id] == 0 and  (old ^ new) & ent_body:
             if       new & ent_body: this.enter(id)
             else: if old & ent_body: this.exit(id)
         return new
+
+    def ent_linked(shard, id:int, pid:int, ex_pid:int):
+        if pid == 0:
+            if shard.type[id] & ent_body: this.enter(id)
+        else: if ex_pid == 0:
+            if shard.type[id] & ent_body: this.exit(id)
 
 //// ancillary component: minds take action
 
@@ -693,6 +707,7 @@ class ent_template:
     glyph = glyph_0
     z     = 0.0
     size  = 1.0
+    cap   = xy_0
 
     rel_in  = entrel_shrug // sets scaffold rel when creating if non-shrug
     rel_out = entrel_shrug // sets scaffold rel when descending if non-shrug
@@ -730,6 +745,7 @@ class ent_template:
 
     def init_entity(shard:shard, id:int, pid:int, r:entrel, loc:xy_f):
         shard.name[id] = name
+        shard.cap[id] = cap
         shard.ren[id] = render { bg, fg, glyph }
         if tile != tile_none: shard.tile[id] = tile
         if item != item_none: shard.item[id] = item
@@ -749,6 +765,8 @@ class ent_template:
     def add_spawn_sibling(template_id:int, prob:xy_i):
         spawn_template.push(template_id)
         spawn_prob.push(prob)
+        spawn_rel.push(entrel_shrug)
+        spawn_at.push(xy_0)
 
     def add_spawn_child(template_id:int, prob:xy_i, rel:entrel, at:xy_f):
         spawn_template.push(template_id)
@@ -892,10 +910,15 @@ def add_spawns(this::spawner, id:int, ctx:ent_scaffold):
         id: id,
         next_spawn_id: spawn_id,
     }
-    for(ctx.tmpl.spawn_template) template_id, i:
+    ctx.under(id): for(ctx.tmpl.spawn_template) template_id, i:
         let p = ctx.tmpl.spawn_prob[i]
         if p != xy_0i: sp.p = p
-        ctx.use_id(template_id): sp.add_spawn(ctx)
+        let spawn_rel = ctx.tmpl.spawn_rel[i]
+        nest_if(spawn_rel) body:
+            ctx.with_rel(spawn_rel):
+                ctx.at(ctx.tmpl.spawn_at[i]):
+                    body()
+        with: ctx.use_id(template_id): sp.add_spawn(ctx)
 
 def add_spawn(this::spawner, id:int, body):
     let n, spawn_id = ids.binary_search(id)

--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -169,10 +169,6 @@ class shard:
     ksh = []::resource? // cached render to texture
     // TODO drop tex aspect, once we switch fully to graph-structured drawing into ksh
 
-    // any associated rule sheet data
-    tile = []::tile_entity_id
-    item = []::item_entity_id
-
     systems = []::system
 
     free_ids = []::int
@@ -195,8 +191,6 @@ class shard:
         emit("@<" + pos[id].x + ", " + pos[id].y + ">")
         emit("z:" + pos[id].z)
         if pos[id].w: emit("size:" + pos[id].w)
-        if tile[id]: emit("" + tile[id])
-        if item[id]: emit("" + item[id])
 
     def describe_draw(id, emit):
         if ren[id].bg != color_clear: emit("bg:" + color_to_hex(ren[id].bg))
@@ -230,8 +224,6 @@ class shard:
             ren.push(render_0)
             tex.push(nil)
             ksh.push(nil)
-            tile.push(tile_none)
-            item.push(item_none)
             return id
         def reuse():
             let id = free_ids.remove_obj(free_ids.min())
@@ -247,8 +239,6 @@ class shard:
             ren[id] = render_0
             tex[id] = nil
             ksh[id] = nil
-            tile[id] = tile_none
-            item[id] = item_none
             return id
         if not type.length: grow() // reserve #0
         return if free_ids.length: reuse() else: grow()
@@ -712,9 +702,6 @@ class ent_template:
     rel_in  = entrel_shrug // sets scaffold rel when creating if non-shrug
     rel_out = entrel_shrug // sets scaffold rel when descending if non-shrug
 
-    tile = tile_none
-    item = item_none
-
     initiative = 0
 
     spawn_template = []::int
@@ -747,8 +734,6 @@ class ent_template:
         shard.name[id] = name
         shard.cap[id] = cap
         shard.ren[id] = render { bg, fg, glyph }
-        if tile != tile_none: shard.tile[id] = tile
-        if item != item_none: shard.item[id] = item
         shard.pos[id] = spatial { loc.x, loc.y, z, size }
         if pid:
             shard.link_after(pid, r, id, 0)

--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -44,7 +44,6 @@ enum_flags entype:
     ent_input       // receives player input
     ent_holds       // can contain other entities (up to cap)
     ent_acts        // used to act upon the world
-    ent_avatar      // has avatar
 
 def entype_str(t:entype):
     let parts = []
@@ -55,7 +54,6 @@ def entype_str(t:entype):
     if t & ent_body:    parts.push("body")
     if t & ent_mind:    parts.push("mind")
     if t & ent_input:   parts.push("input")
-    if t & ent_avatar:  parts.push("avatar")
     if t & ent_holds:  parts.push("holds")
     if t & ent_acts:  parts.push("acts")
     return parts.concat_string("|")
@@ -708,12 +706,6 @@ class ent_template:
     spawn_prob     = []::xy_i
     spawn_rel      = []::entrel
     spawn_at       = []::xy_f
-
-    avatar_helf       = xy_0i
-    avatar_stam       = xy_0i
-    avatar_gives      = false
-    avatar_left_hand  = item_none
-    avatar_right_hand = item_none
 
     child_at = []::xy_f
     childrel = []::entrel

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -282,11 +282,12 @@ class avatars : system
 
 enum_flags trace:
     trace_spawn
+    trace_action
     trace_all // all entities, not just ones with ent_debug set
 
 class chunk : shard
     // debug tracing
-    trace = trace(0) // TODO trace_avatar
+    trace = trace_action
 
     // performance timers
     timers = timers{}
@@ -347,6 +348,126 @@ class chunk : shard
         anims.update(this, dt)
         avatars.update_any(this)
 
+    def walk_rec_sizes(id, body):
+        var size = xy_1
+        this.walk_rec(id) nid, depth, descend:
+            body(nid, size):
+                let c = cap[nid]
+                if c.x != 0 and c.y != 0:
+                    let scale = xy_1 / c * pos[nid].w
+                    size *= scale
+                    descend()
+                    size /= scale
+
+    def actor_at(id, at):
+        let debug = should_trace(id, trace_action)
+
+        /*
+
+        take rule:
+            WHEN ( # acts:size=act ) + ( # holds>_:size ) + ( @ holds>X:size )
+             AND size <= act
+             AND size.sq <= avail
+            THEN holds>X
+             MAX size
+             MIN avail
+            WITH avail = holds:cap.sq - sum( holds>*:size.sq )
+
+        */
+
+        let acts = []::int
+        let acts_size = []::xy_f
+        this.walk_rec_sizes(id) nid, size, descend:
+            if type[nid] & ent_acts:
+                acts.push(nid)
+                acts_size.push(size)
+            else:
+                descend()
+
+        // TODO further capability evaluation
+        if !acts.length:
+            return
+        if debug:
+            print(this.tag(id) + " acts:" + acts + " sz:" + acts_size)
+
+        var max_act = xy_0
+        for(acts_size) size:
+            if max_act.x * max_act.y < size.x * size.y:
+                max_act = size
+
+        let at_held = []::int
+        let at_held_size = []::xy_f
+        for(at) atid: this.walk_rec_sizes(atid) nid, size, descend:
+            if type[nid] & ent_holds:
+                let child_size = size / cap[nid] * pos[nid].w
+                this.walk_next(first[nid]) cid: if rel[cid] == entrel_held:
+                    let sz = child_size * pos[cid].w
+                    // TODO further capability evaluation
+                    if max(max_act) >= min(sz):
+                        at_held.push(cid)
+                        at_held_size.push(sz)
+            else:
+                descend()
+
+        // TODO further capability evaluation
+        if !at_held.length:
+            return
+        if debug:
+            print("@" + at + " held:" + at_held + " sz:" + at_held_size)
+
+        let holds = []::int
+        let holds_cell = []::xy_f
+        let holds_size = []::xy_f
+        let holds_avail = []::float
+        this.walk_rec_sizes(id) nid, size, descend:
+            if type[nid] & ent_holds:
+                let c = cap[nid]
+                let child_size = size / c * pos[nid].w
+                var avail = size.x * size.y
+                this.walk_next(first[nid]) cid: if rel[cid] == entrel_held:
+                    let sz = child_size * pos[cid].w
+                    avail -= sz.x * sz.y
+                if avail > 0:
+                    holds.push(nid)
+                    holds_cell.push(child_size)
+                    holds_size.push(size)
+                    holds_avail.push(avail)
+            else:
+                descend()
+
+        // TODO further capability evaluation
+        if !holds.length:
+            return
+        if debug:
+            print(this.tag(id) + " holds:" + holds + " holds_cell:" + holds_cell + " holds_avail:" + holds_avail + " holds_size:" + holds_size)
+
+        var take_id = -1
+        var into_id = -1
+        var take_size = xy_0
+        for(at_held_size) size, i: if take_size.x * take_size.y < size.x * size.y:
+            var into_avail = 0.0
+            for(holds_avail) avail, j:
+                if into_avail == 0 or into_avail > avail:
+                    into_avail = avail
+                    into_id = j
+            if into_id >= 0:
+                into_id = holds[into_id]
+                take_size = size
+                take_id = i
+        if take_id >= 0:
+            take_id = at_held[take_id]
+            if type[id] & ent_debug:
+                let root_id = this.root_of(take_id)
+                type[root_id] = type[root_id] | ent_debug
+            this.add_child(into_id, entrel_held, take_id)
+            let p = pos[take_id]
+            var sz = p.w // TODO scale!
+            let loc = xy_0 // TODO placement!
+            pos[take_id] = spatial { loc.x + 0.5, loc.y + 0.5, p.z, sz }
+
+            if debug:
+                print(this.tag(id) + " take " + this.tag(take_id) + " into " + this.tag(into_id) + " pos " + p + " => " + pos[take_id])
+
     def actor_move(id, actor_id):
         // animate actor movement, adding to hit group if successful
         let group_id = group_ids[actor_id]
@@ -364,6 +485,9 @@ class chunk : shard
         if at.length == 1 and at[0] == id:
             // TODO special case self action?
             return
+
+        if at.length: // have at!
+            actor_at(id, at)
 
         anims.animate(id, movement_time) anim:
             anim.blocking = true
@@ -386,7 +510,11 @@ class chunk : shard
 
     def bodys_at(loc):
         // TODO spatial query
-        return filter(bodys.ids) id: pos[id].cell() == loc
+        return filter(bodys.ids) id: par[id] == 0 and pos[id].cell() == loc
+
+    def bodys_under(id:int):
+        return collect() each: this.walk_next(first[id]) cid:
+            if type[cid] & ent_body: each(cid)
 
     def step(input:input_fun):
         timers.record_time(0):
@@ -514,10 +642,16 @@ class stacked_scene : system
         zs.remove(scene_id, 1)
 
     def ent_changed(shard, id:int, new:entype, old:entype):
-        if (old ^ new) & ent_visible:
+        if shard.par[id] == 0 and (old ^ new) & ent_visible:
             if       new & ent_visible: this.enter(shard, id)
             else: if old & ent_visible: this.exit(id)
         return new
+
+    def ent_linked(shard, id:int, pid:int, ex_pid:int):
+        if pid == 0:
+            if shard.type[id] & ent_visible: this.enter(shard, id)
+        else: if ex_pid == 0:
+            if shard.type[id] & ent_visible: this.exit(id)
 
     // TODO update_z
 
@@ -561,13 +695,19 @@ def create_with(this::ent_scaffold, chunk:chunk, body):
     if not tmpl.type:
         return
     assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
-    let id = chunk.create(tmpl.type): this.init_entity(chunk, _)
-    let r = chunk.ren[id]
-    if r.glyf == glyph_0:
-        if       tmpl.tile != tile_none: chunk.ren[id] = r.with_glyph(tile_sprite(tmpl.tile))
-        else: if tmpl.item != item_none: chunk.ren[id] = r.with_glyph(item_sprite(tmpl.item))
-    build_entity(chunk, id)
-    body(id, this)
+    with_rel(tmpl.rel_in):
+        let id = chunk.create(tmpl.type): this.init_entity(chunk, _)
+        let r = chunk.ren[id]
+        if r.glyf == glyph_0:
+            if       tmpl.tile != tile_none: chunk.ren[id] = r.with_glyph(tile_sprite(tmpl.tile))
+            else: if tmpl.item != item_none: chunk.ren[id] = r.with_glyph(item_sprite(tmpl.item))
+        build_entity(chunk, id)
+        under(id): with_rel(tmpl.rel_out):
+            at_each(tmpl.child_at) child_id:
+                let childrel = tmpl.childrel[child_id]
+                nest_if(childrel) _: with_rel(childrel): _()
+                with: use(tmpl.children[child_id]): this.create_with(chunk): nil
+            body(id, this)
 
 def create(this::ent_scaffold, chunk:chunk):
     var id = 0
@@ -575,7 +715,9 @@ def create(this::ent_scaffold, chunk:chunk):
     return id
 
 def may_spawn(this::ent_scaffold, chunk:chunk, l:xy_f):
-    let there = chunk.bodys_at(int(l))
+    let there =
+        if par: chunk.bodys_under(par)
+        else:   chunk.bodys_at(int(l))
     // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
     if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
     if tmpl.item != item_none: return !exists(there): chunk.item[_] == tmpl.item
@@ -583,8 +725,8 @@ def may_spawn(this::ent_scaffold, chunk:chunk, l:xy_f):
     return true
 
 def do_spawn(this::ent_scaffold, chunk:chunk, l:xy_f, body):
-    at(l):
-        create_with(chunk, body)
+    nest_if(!par): at(l, _)
+    with: create_with(chunk, body)
 
 def spawn(this::spawner, chunk):
     var last_id = -1

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -505,12 +505,12 @@ def create(this::ent_scaffold, chunk:chunk):
     this.create_with(chunk) _: id = _
     return id
 
-def may_spawn(this::ent_scaffold, chunk:chunk, l:xy_f):
-    if not tmpl.type & ent_body: return true
+def entity_exists(this::ent_scaffold, chunk:chunk, l:xy_f):
+    if not tmpl.type & ent_body: return false
     let there =
         if par: chunk.bodys_under(par)
         else:   chunk.bodys_at(int(l))
-    return !exists(there): chunk.type[_] & ent_body
+    return exists(there): chunk.type[_] & ent_body
 
 def do_spawn(this::ent_scaffold, chunk:chunk, l:xy_f, body):
     nest_if(!par): at(l, _)
@@ -533,7 +533,7 @@ def spawn(this::spawner, chunk):
 
     def can_spawn(spawn_id) -> bool:
         let ctx = scaf[spawn_id]
-        return ctx.may_spawn(chunk, loc)
+        return !ctx.entity_exists(chunk, loc)
 
     def should_spawn(spawn_id) -> bool:
         // TODO other trigger modes or distributions?

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -92,192 +92,6 @@ def for_from(xs, i, body):
         body(xs[i], i)
         i++
 
-//// ancillary component: avatars represent character state
-
-class avatar:
-    retex      = false
-    state      = avatar_state_content
-    moji       = glyph_0
-    helf       = xy { 3, 3 } // ❤️
-    stam       = xy { 0, 0 } // 💛
-    gives      = false
-    left_hand  = item_none
-    right_hand = item_none
-    // TODO worn item
-    // TODO back item
-
-    show_hearts = false
-    show_status = false
-
-    def offer() -> item_entity_id:
-        if not gives:
-            return item_none
-        if right_hand != item_none: return right_hand
-        if  left_hand != item_none: return left_hand
-        return item_none
-
-    def offer_taken():
-        if gives:
-            if right_hand != item_none:
-                right_hand = left_hand
-                left_hand = item_none
-            else: if  left_hand != item_none:
-                left_hand = item_none
-
-    def take(id:item_entity_id) -> bool:
-        if id == item_none:
-            return false
-        if right_hand != item_none:
-            if left_hand != item_none:
-                return false
-            left_hand = right_hand
-        right_hand = id
-        return true
-
-    def drop() -> item_entity_id:
-        if right_hand != item_none:
-            let r = right_hand
-            right_hand = item_none
-            print("dropped right hand " + r)
-            return r
-        if left_hand != item_none:
-            let r = left_hand
-            left_hand = item_none
-            print("dropped left hand " + r)
-            return r
-        return item_none
-
-    def swap():
-        let tmp = right_hand
-        right_hand = left_hand
-        left_hand = tmp
-
-    def use_hand():
-        if right_hand != item_none:
-            print("TODO use " + right_hand) // TODO implement
-            return
-        if left_hand != item_none:
-            right_hand = left_hand
-            left_hand = item_none
-            print("use fault swap")
-            return
-
-    def combine_hands():
-        if right_hand == item_none: return
-        if  left_hand == item_none: return
-        print("TODO combine " + right_hand + " + " + left_hand) // TODO implement
-
-    def faces(each):
-        var i = 0
-        if moji.code != 0:
-            each(moji, i++)
-        if state == avatar_state_content:
-            each(avatar_sprite(avatar_state_entity_ids[0]), i++) // 🙂
-            return
-        for(avatar_state_entity_ids) aeid, j: if j:
-            let q_state = avatar_state(1 << (j - 1))
-            if state & q_state:
-                each(avatar_sprite(aeid), i++)
-
-    def hearts(each):
-        let e = ui_sprite(ui_empty_heart)
-        let h = ui_sprite(ui_health_heart)
-        let s = ui_sprite(ui_stamina_heart)
-        var i = 0
-        for(         helf.x): each(h, i++, 0)
-        for(helf.y - helf.x): each(e, i++, 0)
-        i = 0
-        for(         stam.x): each(h, i++, 1)
-        for(stam.y - stam.x): each(e, i++, 1)
-
-    def draw_tile():
-        let face = xy_1 * 2.0 / 3.0
-        let icon = xy_1 * 1.0 / 5.0
-        let hand = xy_1 * 1.0 / 3.0
-        gl_set_shader("textured")
-        def unit(glyf):
-            gl_set_primitive_texture(0, glyf.get_texture())
-            gl_unit_square()
-        faces() glyf, i:
-            if i == 0:
-                gl_translate(xy_1 / 6): gl_scale(face):
-                    unit(glyf)
-            else: if show_status:
-                gl_scale(icon):
-                    gl_translate(xy_f { 4 - (i - 1) / 3, (i - 1) % 3 }):
-                        unit(glyf)
-        if show_hearts:
-            hearts() heart, x, y:
-                gl_scale(icon):
-                    gl_translate(xy_f { y, x }):
-                        unit(heart)
-        gl_scale(hand): gl_translate(xy_f { 0, 2 }):
-            unit(if left_hand: item_sprite(left_hand)
-                 else:         ui_sprite(ui_left_hand))
-        gl_scale(hand): gl_translate(xy_f { 2, 2 }):
-            unit(if right_hand: item_sprite(right_hand)
-                 else:          ui_sprite(ui_right_hand))
-
-class avatars : system
-    ids     = []::int
-    avatars = []::avatar
-
-    res = xy_i { 144, 144 }
-
-    def update_tex(shard, av, id):
-        shard.tex[id] = sprite_render(res):
-            gl_scale(float(res)):
-                av.draw_tile()
-        av.retex = false
-        shard.invalidate(id)
-
-    def update_any(shard):
-        for(avatars) av, avatar_id: if av.retex:
-            update_tex(shard, av, ids[avatar_id])
-
-    def get(id:int) -> avatar?:
-        let n, avatar_id = ids.binary_search(id)
-        return if n: avatars[avatar_id] else: nil
-
-    def with(shard, id:int, body):
-        shard.add_type(id, ent_avatar)
-        let n, avatar_id = ids.binary_search(id)
-        assert n
-        let av = avatars[avatar_id]
-        body(av)
-        av.retex = true
-
-    def enter(shard, id, type):
-        let n, avatar_id = ids.binary_search(id)
-        if not n:
-            let show = if shard.type[id] & ent_input: true else: false
-            ids.insert(avatar_id, id)
-            avatars.insert(avatar_id, avatar {
-                moji:        shard.ren[id].glyf,
-                retex:       true,
-                show_hearts: show,
-                show_status: show,
-            })
-
-    def exit(shard, id):
-        let n, avatar_id = ids.binary_search(id)
-        if n:
-            ids.remove(avatar_id, n)
-            avatars.remove(avatar_id, n)
-            shard.tex[id] = nil
-            shard.invalidate(id)
-
-    def ent_changed(shard, id:int, new:entype, old:entype):
-        if (old ^ new) & ent_avatar:
-            if       new & ent_avatar: this.enter(shard, id, new)
-            else: if old & ent_avatar: this.exit(shard, id)
-        else: if shard.type[id] & ent_avatar and (old ^ new) & ent_input:
-            let show = if new & ent_input: true else: false
-            this.with(shard, id) av:
-                av.show_hearts = show
-                av.show_status = show
-        return new
-
 //// shard integration
 
 enum_flags trace:
@@ -288,7 +102,7 @@ enum_flags trace:
 
 class chunk : shard
     // debug tracing
-    trace = trace_action
+    trace = trace(0)
 
     // performance timers
     timers = timers{}
@@ -297,7 +111,6 @@ class chunk : shard
     spawner = spawner {}
     minds   = minds {}
     bodys   = bodys {}
-    avatars = avatars {}
     anims   = anims {}
 
     movement_time = 1.0 / 4
@@ -362,7 +175,6 @@ class chunk : shard
 
     def update(dt:float):
         anims.update(this, dt)
-        avatars.update_any(this)
 
     def walk_rec_sizes(id, body):
         var size = xy_1
@@ -377,6 +189,12 @@ class chunk : shard
 
     def actor_at(id, at):
         let debug = should_trace(id, trace_action)
+        if debug: print_list(this.tag(id) + " interacts with", 0) level, print_item:
+            for(at) at_id:
+                let item = build_string() emit:
+                    emit(this.tag(at_id))
+                    this.describe_intrinsics(at_id, emit)
+                print_item(item)
 
         /*
 
@@ -400,11 +218,12 @@ class chunk : shard
             else:
                 descend()
 
-        // TODO further capability evaluation
+        // TODO further capability evaluation; especially abilities conferred from held items
         if !acts.length:
             return
-        if debug:
-            print(this.tag(id) + " acts:" + acts + " sz:" + acts_size)
+        if debug: print_list("acts with one of", 1) level, print_item:
+            for(acts) act_id, i: print_item(this.tag(act_id) +
+                " size:" + acts_size[i])
 
         var max_act = xy_0
         for(acts_size) size:
@@ -428,8 +247,10 @@ class chunk : shard
         // TODO further capability evaluation
         if !at_held.length:
             return
-        if debug:
-            print("@" + at + " held:" + at_held + " sz:" + at_held_size)
+        if debug: print_list("at held items", 1) level, print_item:
+            for(at_held) held_id, i: print_item(this.tag(held_id) +
+                " size:" + at_held_size[i] +
+                " in:" + this.tag(this.par[held_id]))
 
         let holds = []::int
         let holds_cell = []::xy_f
@@ -454,8 +275,11 @@ class chunk : shard
         // TODO further capability evaluation
         if !holds.length:
             return
-        if debug:
-            print(this.tag(id) + " holds:" + holds + " holds_cell:" + holds_cell + " holds_avail:" + holds_avail + " holds_size:" + holds_size)
+        if debug: print_list("take into one of", 1) level, print_item:
+            for(holds) hold_id, i: print_item(this.tag(hold_id) +
+                " holds_cell:" + holds_cell[i] +
+                " holds_avail:" + holds_avail[i] +
+                " holds_size:" + holds_size[i])
 
         var take_id = -1
         var into_id = -1
@@ -463,26 +287,36 @@ class chunk : shard
         for(at_held_size) size, i: if take_size.x * take_size.y < size.x * size.y:
             var into_avail = 0.0
             for(holds_avail) avail, j:
-                if into_avail == 0 or into_avail > avail:
+                if into_avail == 0 or into_avail < avail:
                     into_avail = avail
                     into_id = j
-            if into_id >= 0:
-                into_id = holds[into_id]
-                take_size = size
+            if into_avail > 0:
                 take_id = i
-        if take_id >= 0:
+                take_size = size
+
+        if take_id >= 0 and into_id >= 0:
             take_id = at_held[take_id]
-            if type[id] & ent_debug:
-                let root_id = this.root_of(take_id)
-                type[root_id] = type[root_id] | ent_debug
+            let root_id = this.root_of(take_id)
+            if debug: print("  -" +
+                " take:" + this.tag(take_id) +
+                " from:" + this.tag(root_id) +
+                " size:" + take_size)
+
+            into_id = holds[into_id]
+            if debug: print("  -" +
+                " into:" + this.tag(into_id) +
+                " of:" + this.tag(this.root_of(into_id)) +
+                " avail:" + holds_avail[into_id])
+
             this.add_child(into_id, entrel_held, take_id)
             let p = pos[take_id]
-            var sz = p.w // TODO scale!
-            let loc = xy_0 // TODO placement!
-            pos[take_id] = spatial { loc.x + 0.5, loc.y + 0.5, p.z, sz }
+            let loc = xy_0 // TODO place in a free cell
+            pos[take_id] = spatial { loc.x + 0.5, loc.y + 0.5, p.z, p.w }
 
-            if debug:
-                print(this.tag(id) + " take " + this.tag(take_id) + " into " + this.tag(into_id) + " pos " + p + " => " + pos[take_id])
+            if debug: print("  -" +
+                " beheld:" + this.tag(take_id))
+            else:
+                print(this.tag(id) + " took " + this.tag(take_id) + " from " + this.tag(root_id))
 
     def actor_move(id, actor_id):
         // animate actor movement, adding to hit group if successful
@@ -570,52 +404,20 @@ class chunk : shard
             for(groups) actors:
                 for(actors) actor_id:
                     let id = actor_ids[actor_id]
-                    if type[id] & ent_avatar:
-                        avatar_move(id, actor_id)
-                    else:
-                        actor_move(id, actor_id)
-
-    def avatar_move(id, actor_id):
-        avatars.with(this, id) av:
-            let act = actions[actor_id]
-            def boop(object_id) -> bool:
-                // TODO take av.right_hand into account? combat? digging? crafting-at?
-                let t = type[object_id]
-                if t & ent_avatar: avatars.with(this, object_id) other_av:
-                    let offered = other_av.offer()
-                    if offered:
-                        // TODO could open offered modal
-                        if av.take(offered):
-                            other_av.offer_taken()
-                            print(this.tag(id) + " took offered " + offered + " from " + this.tag(object_id))
-                            return true
-                        else:
-                            print(this.tag(id) + " decline offered " + offered + " from " + this.tag(object_id))
-                    else:
-                        print(this.tag(id) + " shrug at " + this.tag(object_id))
-                    return false
-                // TODO avatar state (hand items) X object
-                print(this.tag(id) + " booped an unknown type:" + entype_str(t) + " from " + this.tag(object_id))
-                return false
-
-            switch act.act:
-                case action_none:         nil
-                case action_hand_drop:    av.drop()
-                case action_hand_swap:    av.swap()
-                case action_hand_use:     av.use_hand()
-                case action_hand_combine: av.combine_hands()
-                case action_move:
-                    if act.dir == xy_0:
-                        print(this.tag(id) + " rest...") // TODO and then...
-                    else:
-                        actor_find_at(actor_id) object_id: boop(object_id)
-                        actor_move(id, actor_id)
+                    // XXX
+                    // switch act.act:
+                    //     case action_none:         nil
+                    //     case action_hand_drop:    av.drop()
+                    //     case action_hand_swap:    av.swap()
+                    //     case action_hand_use:     av.use_hand()
+                    //     case action_hand_combine: av.combine_hands()
+                    //     case action_move:
+                    actor_move(id, actor_id)
 
 def new_chunk():
     let ch = chunk {}
     ch.systems.push(ch.minds)
     ch.systems.push(ch.bodys)
-    ch.systems.push(ch.avatars)
     ch.systems.push(ch.spawner)
 
     ch.timers.add("step", 64)             // 0
@@ -684,12 +486,6 @@ class stacked_scene : system
 def build_entity(this::ent_scaffold, chunk:chunk, id:int):
     if tmpl.type & ent_mind:
         chunk.minds.set_init(id, tmpl.initiative)
-    if tmpl.type & ent_avatar: chunk.avatars.with(chunk, id) av:
-        if tmpl.avatar_helf.y     != 0:         av.helf       = tmpl.avatar_helf
-        if tmpl.avatar_stam.y     != 0:         av.stam       = tmpl.avatar_stam
-        if tmpl.avatar_gives:                   av.gives      = tmpl.avatar_gives
-        if tmpl.avatar_left_hand  != item_none: av.left_hand  = tmpl.avatar_left_hand
-        if tmpl.avatar_right_hand != item_none: av.right_hand = tmpl.avatar_right_hand
     if tmpl.spawn_template.length:
         chunk.spawner.add_spawns(id, this)
 
@@ -832,56 +628,158 @@ let tree_deciduous = templates.define(ent_body | ent_visible | ent_holds):
     _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 3 })
     _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 3 })
 
-let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar | ent_input | ent_debug):
-    _.name = "player"
+let left_hand_template = templates.define(ent_body | ent_visible | ent_holds | ent_acts):
+    _.name = "left hand"
     _.z    = 1.0
     _.size = 1.0
     _.fg   = color_white
+    _.glyph = ui_sprite(ui_left_hand)
+    _.cap = xy_f { 1, 1 }
+
+let right_hand_template = templates.define(ent_body | ent_visible | ent_holds | ent_acts):
+    _.name = "right hand"
+    _.z    = 1.0
+    _.size = 1.0
+    _.fg   = color_white
+    _.glyph = ui_sprite(ui_right_hand)
+    _.cap = xy_f { 1, 1 }
+
+let heart_template = templates.define(ent_body | ent_visible):
+    _.name = "heart"
+    _.z    = 1.0
+    _.size = 0.5
+    _.fg   = color_white
+    _.glyph = ui_sprite(ui_health_heart) // ❤️
+
+let stamina_heart_template = templates.define(ent_body | ent_visible):
+    _.name = "stamheart"
+    _.z    = 1.0
+    _.size = 0.5
+    _.fg   = color_white
+    _.glyph = ui_sprite(ui_stamina_heart) // 💛
+
+let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_input | ent_debug):
+    _.name  = "player"
+    _.glyph = avatar_sprite(avatar_content) // 🙂
+    _.fg    = color_white
+    _.z     = 1.0
+    _.size  = 1.0
+    _.cap   = xy_f { 3, 3 }
     _.initiative = 10
 
-let element_earth = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
-    _.name = "earth elemental"
-    _.z    = 1.0
-    _.size = 1.0
+    _.add_child(entrel_body, xy_f { 0, 2 }, templates.defs[left_hand_template])
+    _.add_child(entrel_body, xy_f { 2, 2 }, templates.defs[right_hand_template])
+
+    // TODO would it be better to have a heart-container?
+    let off = xy_f { -0.25, -0.25 }
+    let heart = templates.defs[heart_template]
+    _.add_child(entrel_body, xy_f { 0.0, 0 } + off, heart)
+    _.add_child(entrel_body, xy_f { 0.5, 0 } + off, heart)
+    _.add_child(entrel_body, xy_f { 1.0, 0 } + off, heart)
+
+let gift_earth = templates.define(ent_body | ent_visible):
+    _.name = "gift of earth"
+    _.z     = 0.75
+    _.size  = 1.0
     _.glyph = item_sprite(item_clover)
-    _.fg = color_dark_green
-    _.initiative = 3
-    _.avatar_gives = true
-    _.avatar_left_hand = item_clover
-    _.avatar_right_hand = item_clover
+    _.fg    = color_dark_green
 
-let element_water = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
-    _.name = "water elemental"
-    _.z    = 1.0
-    _.size = 1.0
+let gift_water = templates.define(ent_body | ent_visible):
+    _.name = "gift of water"
+    _.z     = 0.75
+    _.size  = 1.0
     _.glyph = item_sprite(item_water)
-    _.fg = color_teal
-    _.initiative = 4
-    _.avatar_gives = true
-    _.avatar_left_hand = item_water
-    _.avatar_right_hand = item_water
+    _.fg    = color_teal
 
-let element_fire = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
-    _.name = "fire elemental"
-    _.z    = 1.0
-    _.size = 1.0
+let gift_fire = templates.define(ent_body | ent_visible):
+    _.name = "gift of fire"
+    _.z     = 0.75
+    _.size  = 1.0
     _.glyph = item_sprite(item_fire)
-    _.fg = color_orange
-    _.initiative = 6
-    _.avatar_gives = true
-    _.avatar_left_hand = item_fire
-    _.avatar_right_hand = item_fire
+    _.fg    = color_orange
 
-let element_air = templates.define(ent_body | ent_visible | ent_mind | ent_avatar):
-    _.name = "air elemental"
-    _.z    = 1.0
-    _.size = 1.0
+let gift_air = templates.define(ent_body | ent_visible):
+    _.name = "gift of air"
+    _.z     = 0.75
+    _.size  = 1.0
     _.glyph = item_sprite(item_wind)
-    _.fg = color_cyan
+    _.fg    = color_cyan
+
+let element_earth = templates.define(ent_body | ent_visible | ent_mind):
+    _.name  = "earth elemental"
+    _.glyph = item_sprite(item_clover)
+    _.fg    = color_dark_green
+    _.z     = 1.0
+    _.size  = 1.0
+    _.cap   = xy_f { 3, 3 }
+    _.initiative = 3
+
+    let left_hand  = templates.defs[left_hand_template].dupe()
+    let right_hand = templates.defs[right_hand_template].dupe()
+    let gift       = templates.defs[gift_earth]
+    left_hand.glyph = glyph_0
+    right_hand.glyph = glyph_0
+    left_hand.add_child(entrel_held, xy_0, gift)
+    right_hand.add_child(entrel_held, xy_0, gift)
+    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
+    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
+
+let element_water = templates.define(ent_body | ent_visible | ent_mind):
+    _.name  = "water elemental"
+    _.glyph = item_sprite(item_water)
+    _.fg    = color_teal
+    _.z     = 1.0
+    _.size  = 1.0
+    _.cap   = xy_f { 3, 3 }
+    _.initiative = 4
+
+    let left_hand  = templates.defs[left_hand_template].dupe()
+    let right_hand = templates.defs[right_hand_template].dupe()
+    let gift       = templates.defs[gift_water]
+    left_hand.glyph = glyph_0
+    right_hand.glyph = glyph_0
+    left_hand.add_child(entrel_held, xy_0, gift)
+    right_hand.add_child(entrel_held, xy_0, gift)
+    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
+    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
+
+let element_fire = templates.define(ent_body | ent_visible | ent_mind):
+    _.name  = "fire elemental"
+    _.glyph = item_sprite(item_fire)
+    _.fg    = color_orange
+    _.z     = 1.0
+    _.size  = 1.0
+    _.cap   = xy_f { 3, 3 }
     _.initiative = 5
-    _.avatar_gives = true
-    _.avatar_left_hand = item_wind
-    _.avatar_right_hand = item_wind
+
+    let left_hand  = templates.defs[left_hand_template].dupe()
+    let right_hand = templates.defs[right_hand_template].dupe()
+    let gift       = templates.defs[gift_fire]
+    left_hand.glyph = glyph_0
+    right_hand.glyph = glyph_0
+    left_hand.add_child(entrel_held, xy_0, gift)
+    right_hand.add_child(entrel_held, xy_0, gift)
+    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
+    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
+
+let element_air = templates.define(ent_body | ent_visible | ent_mind):
+    _.name  = "air elemental"
+    _.glyph = item_sprite(item_wind)
+    _.fg    = color_cyan
+    _.z     = 1.0
+    _.size  = 1.0
+    _.cap   = xy_f { 3, 3 }
+    _.initiative = 6
+
+    let left_hand  = templates.defs[left_hand_template].dupe()
+    let right_hand = templates.defs[right_hand_template].dupe()
+    let gift       = templates.defs[gift_air]
+    left_hand.glyph = glyph_0
+    right_hand.glyph = glyph_0
+    left_hand.add_child(entrel_held, xy_0, gift)
+    right_hand.add_child(entrel_held, xy_0, gift)
+    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
+    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
 
 def build_world(chunk):
     let size = 12

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -283,6 +283,7 @@ class avatars : system
 enum_flags trace:
     trace_spawn
     trace_action
+    trace_render
     trace_all // all entities, not just ones with ent_debug set
 
 class chunk : shard
@@ -315,6 +316,21 @@ class chunk : shard
             if type[id] & ent_debug: return true
         return false
 
+    def render_ent_graph(id):
+        let debug = should_trace(id, trace_render)
+        if debug:
+            print("render " + this.tag(id))
+        this.walk_rec(id) nid, depth, descend: if type[nid] & ent_visible:
+            if debug:
+                print("... " + this.describe(nid))
+            nest_if(depth > 0) body:
+                let c = cap[par[nid]]
+                let child_size = if c == xy_0: xy_1 else: xy_1 / c
+                transform_ent(nid, child_size, body)
+            with:
+                render_ent(nid)
+                descend() // TODO z-ordering?
+
     def render_ent(id):
         let tx = tex[id]
         if tx:
@@ -334,7 +350,7 @@ class chunk : shard
         let tx_size = xy_i { int(size.x), int(size.y) }
         if !tx or gl_texture_size(tx) != tx_size:
             tx = render_to_texture(nil, tx_size, false, nil, texture_format_clamp | texture_format_nomipmap):
-                gl_scale(size): render_ent(id)
+                gl_scale(size): render_ent_graph(id)
             ksh[id] = tx
         assert tx // FIXME
         gl_set_shader("textured")

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -594,22 +594,8 @@ class chunk : shard
                     else:
                         print(this.tag(id) + " shrug at " + this.tag(object_id))
                     return false
-                let tile_id = tile[object_id]
-                let item_id = item[object_id]
-                if item_id != item_none:
-                    if av.take(item_id):
-                        this.set_type(object_id, ent_none)
-                        print(this.tag(id) + " took " + item_id + " from " + this.tag(object_id))
-                        return true
-                    else:
-                        print(this.tag(id) + " pass " + item_id + " from " + this.tag(object_id))
-                else: if tile_id != tile_none:
-                    // TODO gathering from tiles, climbing onto tiles, entering
-                    // vehicle tiles, enter any inner space, ...
-                    print(this.tag(id) + " TODO " + tile_id + " from " + this.tag(object_id))
-                else:
-                    // TODO avatar state (hand items) X object
-                    print(this.tag(id) + " booped an unknown type:" + entype_str(t) + " from " + this.tag(object_id))
+                // TODO avatar state (hand items) X object
+                print(this.tag(id) + " booped an unknown type:" + entype_str(t) + " from " + this.tag(object_id))
                 return false
 
             switch act.act:
@@ -708,15 +694,8 @@ def build_entity(this::ent_scaffold, chunk:chunk, id:int):
         chunk.spawner.add_spawns(id, this)
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
-    if not tmpl.type:
-        return
-    assert tmpl.tile == tile_none or tmpl.item == item_none // may have associated tile or item sheet data, but not both
-    with_rel(tmpl.rel_in):
+    if tmpl.type: with_rel(tmpl.rel_in):
         let id = chunk.create(tmpl.type): this.init_entity(chunk, _)
-        let r = chunk.ren[id]
-        if r.glyf == glyph_0:
-            if       tmpl.tile != tile_none: chunk.ren[id] = r.with_glyph(tile_sprite(tmpl.tile))
-            else: if tmpl.item != item_none: chunk.ren[id] = r.with_glyph(item_sprite(tmpl.item))
         build_entity(chunk, id)
         under(id): with_rel(tmpl.rel_out):
             at_each(tmpl.child_at) child_id:
@@ -731,14 +710,11 @@ def create(this::ent_scaffold, chunk:chunk):
     return id
 
 def may_spawn(this::ent_scaffold, chunk:chunk, l:xy_f):
+    if not tmpl.type & ent_body: return true
     let there =
         if par: chunk.bodys_under(par)
         else:   chunk.bodys_at(int(l))
-    // tiles are exclusive, items are unique, bodys are exclusive, otherwise ... sure?
-    if tmpl.tile != tile_none: return !exists(there): chunk.tile[_] != tile_none
-    if tmpl.item != item_none: return !exists(there): chunk.item[_] == tmpl.item
-    if tmpl.type & ent_body: return !exists(there): chunk.type[_] & ent_body
-    return true
+    return !exists(there): chunk.type[_] & ent_body
 
 def do_spawn(this::ent_scaffold, chunk:chunk, l:xy_f, body):
     nest_if(!par): at(l, _)
@@ -820,32 +796,41 @@ let floor_template = templates.define(ent_cell | ent_visible):
 let tmpl_item_pine_apple = templates.define(ent_body | ent_visible):
     _.name = "pineapple"
     _.z    = 0.75
-    _.size = 1.0 / 3.0
+    _.size = 1.0
     _.fg   = color_white
-    _.item = item_pine_apple
+    _.glyph = item_sprite(item_pine_apple)
 
 let tmpl_item_apple = templates.define(ent_body | ent_visible):
     _.name = "apple"
     _.z    = 0.75
-    _.size = 1.0 / 3.0
+    _.size = 1.0
     _.fg   = color_white
-    _.item = item_apple
+    _.glyph = item_sprite(item_apple)
 
-let tree_evergreen = templates.define(ent_body | ent_visible):
+let tree_evergreen = templates.define(ent_body | ent_visible | ent_holds):
     _.name = "evergreen tree"
     _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
-    _.tile = tile_pine_tree
-    _.add_spawn_sibling(tmpl_item_pine_apple, xy_i { 5, 1000 })
+    _.glyph = tile_sprite(tile_pine_tree)
+    _.cap = xy_f { 3, 4 }
+    _.add_spawn_child(tmpl_item_pine_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 0 })
+    _.add_spawn_child(tmpl_item_pine_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 1 })
+    _.add_spawn_child(tmpl_item_pine_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
 
-let tree_deciduous = templates.define(ent_body | ent_visible):
+let tree_deciduous = templates.define(ent_body | ent_visible | ent_holds):
     _.name = "deciduous tree"
     _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
-    _.tile = tile_apple_tree
-    _.add_spawn_sibling(tmpl_item_apple, xy_i { 5, 1000 })
+    _.glyph = tile_sprite(tile_apple_tree)
+    _.cap = xy_f { 6, 6 }
+    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
+    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 2 })
+    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 2 })
+    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 4, 2 })
+    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 3 })
+    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 3 })
 
 let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_avatar | ent_input | ent_debug):
     _.name = "player"


### PR DESCRIPTION
Building on the graph support introduced by #17 

Use graph structure for hierarchical tile rendering, with better cache invalidation than before: previously, just reading an avatar would invalidate its texture; now things are only invalidated on change.

Fully erase the usage of item and tile components, instead going towards a world where all "tile" and "item" semantics are expressed directly (someday!) by compiling sheet data into template code ( as exhibited by the current prototype ). One **crucial** angle here is that we now rely on glyph ids as the fundamental unit of identity for "what is that?". There may be something additional needed here, but for now let's see if we can get away with things like "two explicit empty heart glyphs" so that we know the difference between an "empty stamina heart" and an "empty health heart" when recharging.

Replace the avatar system entirely with movement interactions based on graph relations like:
- action mediated by a sub-entity tagged for action ( e.g a hand )
- enumerate any held sub-entities in the target as potential things to grab
- enumerate all container sub-entities on the actor that can hold an item

Note especially the dimensional translation, that preservers "an apple within a tree with 6x6 grid maintains the same absolute size when held in by a player (3x3 grid)'s hand".

TODO:
- [x] a hard lock ( probably infinite loop ) has crept in during development; there was a time when interaction worked, but it has since turned into a crash
- [x] even when interaction worked, there was a visible bug, taking an apple from a tree half worked: the hand-sub item appeared, but the tree itself was now drawn with a full-size apple glyph
- [ ] ~~not yet dealing with hearts, however those weren't finished in the prior avatar system, and I'll likely punt them to future work~~

Got it all working finally, going to punt heart logic, item dropping, hand swapping, and such to future work.