### PR TITLE
Post graph cleanup: drop the ent_templates container

### DIFF
--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -776,8 +776,6 @@ class ent_templates:
         return register(defs[base_id].extend(body))
 
 class ent_scaffold:
-    templates : ent_templates
-
     tmpl = ent_template { type : ent_none }
 
     loc = xy_0            // location cell in parent or world
@@ -812,9 +810,6 @@ class ent_scaffold:
         tmpl = template
         body()
         tmpl = old_tmpl
-
-    def use_id(template_id:int, body):
-        use(templates.defs[template_id], body)
 
     def at(l:xy_f, body):
         let old_loc = loc

--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -711,6 +711,11 @@ class ent_template:
     childrel = []::entrel
     children = []::ent_template
 
+    def extend(body):
+        let tmpl = dupe()
+        body(tmpl)
+        return tmpl
+
     def dupe():
         let tmpl = copy(this)
         tmpl.spawn_template = copy(tmpl.spawn_template)
@@ -768,9 +773,7 @@ class ent_templates:
         return register(tmpl)
 
     def extend(base_id, body):
-        let tmpl = defs[base_id].dupe()
-        body(tmpl)
-        return register(tmpl)
+        return register(defs[base_id].extend(body))
 
 class ent_scaffold:
     templates : ent_templates

--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -756,18 +756,21 @@ let ent_0 = ent_template { type: ent_none }
 class ent_templates:
     defs = []::ent_template
 
-    def register(tmpl, body):
+    def register(tmpl):
         if not defs.length: defs.push(ent_0)
         let id = defs.length
         defs.push(tmpl)
-        body(tmpl, id)
         return id
 
     def define(t:entype, body):
-        return register(ent_template { type: t }, body)
+        let tmpl = ent_template { type: t }
+        body(tmpl)
+        return register(tmpl)
 
     def extend(base_id, body):
-        return register(defs[base_id].dupe(), body)
+        let tmpl = defs[base_id].dupe()
+        body(tmpl)
+        return register(tmpl)
 
 class ent_scaffold:
     templates : ent_templates

--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -702,10 +702,10 @@ class ent_template:
 
     initiative = 0
 
-    spawn_template = []::int
-    spawn_prob     = []::xy_i
-    spawn_rel      = []::entrel
-    spawn_at       = []::xy_f
+    spawn      = []::ent_template
+    spawn_prob = []::xy_i
+    spawn_rel  = []::entrel
+    spawn_at   = []::xy_f
 
     child_at = []::xy_f
     childrel = []::entrel
@@ -718,7 +718,7 @@ class ent_template:
 
     def dupe():
         let tmpl = copy(this)
-        tmpl.spawn_template = copy(tmpl.spawn_template)
+        tmpl.spawn = copy(tmpl.spawn)
         tmpl.spawn_prob = copy(tmpl.spawn_prob)
         tmpl.spawn_rel = copy(tmpl.spawn_rel)
         tmpl.spawn_at = copy(tmpl.spawn_at)
@@ -744,14 +744,14 @@ class ent_template:
         children.push(tmpl) // TODO should copy?
         return child_id
 
-    def add_spawn_sibling(template_id:int, prob:xy_i):
-        spawn_template.push(template_id)
+    def add_spawn_sibling(tmpl:ent_template, prob:xy_i):
+        spawn.push(tmpl)
         spawn_prob.push(prob)
         spawn_rel.push(entrel_shrug)
         spawn_at.push(xy_0)
 
-    def add_spawn_child(template_id:int, prob:xy_i, rel:entrel, at:xy_f):
-        spawn_template.push(template_id)
+    def add_spawn_child(tmpl:ent_template, prob:xy_i, rel:entrel, at:xy_f):
+        spawn.push(tmpl)
         spawn_prob.push(prob)
         spawn_rel.push(rel)
         spawn_at.push(at)
@@ -893,7 +893,7 @@ def add_spawns(this::spawner, id:int, ctx:ent_scaffold):
         id: id,
         next_spawn_id: spawn_id,
     }
-    ctx.under(id): for(ctx.tmpl.spawn_template) template_id, i:
+    ctx.under(id): for(ctx.tmpl.spawn) tmpl, i:
         let p = ctx.tmpl.spawn_prob[i]
         if p != xy_0i: sp.p = p
         let spawn_rel = ctx.tmpl.spawn_rel[i]
@@ -901,7 +901,7 @@ def add_spawns(this::spawner, id:int, ctx:ent_scaffold):
             ctx.with_rel(spawn_rel):
                 ctx.at(ctx.tmpl.spawn_at[i]):
                     body()
-        with: ctx.use_id(template_id): sp.add_spawn(ctx)
+        with: ctx.use(tmpl): sp.add_spawn(ctx)
 
 def add_spawn(this::spawner, id:int, body):
     let n, spawn_id = ids.binary_search(id)

--- a/src/ecs.lobster
+++ b/src/ecs.lobster
@@ -758,22 +758,10 @@ class ent_template:
 
 let ent_0 = ent_template { type: ent_none }
 
-class ent_templates:
-    defs = []::ent_template
-
-    def register(tmpl):
-        if not defs.length: defs.push(ent_0)
-        let id = defs.length
-        defs.push(tmpl)
-        return id
-
-    def define(t:entype, body):
-        let tmpl = ent_template { type: t }
-        body(tmpl)
-        return register(tmpl)
-
-    def extend(base_id, body):
-        return register(defs[base_id].extend(body))
+def new_template(t:entype, body):
+    let tmpl = ent_template { type: t }
+    body(tmpl)
+    return tmpl
 
 class ent_scaffold:
     tmpl = ent_template { type : ent_none }

--- a/src/ecs_test.lobster
+++ b/src/ecs_test.lobster
@@ -1,18 +1,16 @@
 import ecs
 import testing
 
-let templates = ent_templates {}
+let t_a = new_template(ent_visible): nil
+let t_b = new_template(ent_visible): nil
 
-let t_a = templates.define(ent_visible): nil
-let t_b = templates.define(ent_visible): nil
-
-def make_place(body): return templates.define(ent_visible):
+def make_place(body): return new_template(ent_visible):
     _.z    = 1.0
     _.size = 1.0
     _.fg   = color_white
     body(_)
 
-def make_body(body): return templates.define(ent_visible | ent_body):
+def make_body(body): return new_template(ent_visible | ent_body):
     _.z    = 1.0
     _.size = 1.0
     _.fg   = color_white
@@ -23,10 +21,10 @@ run_test("ecs/templates/spawn"):
     let t_stuff_a = make_place(): _.add_spawn_sibling(t_a, xy_i { 1, 2 })
     let t_stuff_b = make_place(): _.add_spawn_sibling(t_b, xy_i { 1, 3 })
 
-    assert templates.defs[t_stuff_a].spawn.length == 1
-    assert templates.defs[t_stuff_b].spawn.length == 1
-    assert templates.defs[t_a].spawn.length == 0
-    assert templates.defs[t_b].spawn.length == 0
+    assert t_stuff_a.spawn.length == 1
+    assert t_stuff_b.spawn.length == 1
+    assert t_a.spawn.length == 0
+    assert t_b.spawn.length == 0
 
 run_test("ecs/templates/graph"):
     // data should not leak
@@ -34,17 +32,17 @@ run_test("ecs/templates/graph"):
     let t_part2 = make_body(): _.glyph = ascii('b')
 
     def make_thing(body): return make_body(): body(_) // XXX  _.cap = xy_f { 2, 2 }
-    let thing1 = make_thing(): _.add_child(entrel_body, xy_f { 0, 0 }, templates.defs[t_part1])
-    let thing2 = make_thing(): _.add_child(entrel_body, xy_f { 0, 0 }, templates.defs[t_part2])
+    let thing1 = make_thing(): _.add_child(entrel_body, xy_f { 0, 0 }, t_part1)
+    let thing2 = make_thing(): _.add_child(entrel_body, xy_f { 0, 0 }, t_part2)
     let thing3 = make_thing(): nil
 
-    assert templates.defs[t_part1].children.length == 0
-    assert templates.defs[t_part2].children.length == 0
-    assert templates.defs[thing1].children.length == 1
-    assert templates.defs[thing1].children[0].glyph == ascii('a')
-    assert templates.defs[thing2].children.length == 1
-    assert templates.defs[thing2].children[0].glyph == ascii('b')
-    assert templates.defs[thing3].children.length == 0
+    assert t_part1.children.length == 0
+    assert t_part2.children.length == 0
+    assert thing1.children.length == 1
+    assert thing1.children[0].glyph == ascii('a')
+    assert thing2.children.length == 1
+    assert thing2.children[0].glyph == ascii('b')
+    assert thing3.children.length == 0
 
 def ascii(code:int): return glyph { 0, code }
 

--- a/src/ecs_test.lobster
+++ b/src/ecs_test.lobster
@@ -23,10 +23,10 @@ run_test("ecs/templates/spawn"):
     let t_stuff_a = make_place(): _.add_spawn_sibling(t_a, xy_i { 1, 2 })
     let t_stuff_b = make_place(): _.add_spawn_sibling(t_b, xy_i { 1, 3 })
 
-    assert templates.defs[t_stuff_a].spawn_template.length == 1
-    assert templates.defs[t_stuff_b].spawn_template.length == 1
-    assert templates.defs[t_a].spawn_template.length == 0
-    assert templates.defs[t_b].spawn_template.length == 0
+    assert templates.defs[t_stuff_a].spawn.length == 1
+    assert templates.defs[t_stuff_b].spawn.length == 1
+    assert templates.defs[t_a].spawn.length == 0
+    assert templates.defs[t_b].spawn.length == 0
 
 run_test("ecs/templates/graph"):
     // data should not leak

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -636,13 +636,9 @@ let left_hand_template = templates.define(ent_body | ent_visible | ent_holds | e
     _.glyph = ui_sprite(ui_left_hand)
     _.cap = xy_f { 1, 1 }
 
-let right_hand_template = templates.define(ent_body | ent_visible | ent_holds | ent_acts):
+let right_hand_template = templates.extend(left_hand_template):
     _.name = "right hand"
-    _.z    = 1.0
-    _.size = 1.0
-    _.fg   = color_white
     _.glyph = ui_sprite(ui_right_hand)
-    _.cap = xy_f { 1, 1 }
 
 let heart_template = templates.define(ent_body | ent_visible):
     _.name = "heart"
@@ -651,24 +647,24 @@ let heart_template = templates.define(ent_body | ent_visible):
     _.fg   = color_white
     _.glyph = ui_sprite(ui_health_heart) // ❤️
 
-let stamina_heart_template = templates.define(ent_body | ent_visible):
+let stamina_heart_template = templates.extend(heart_template):
     _.name = "stamheart"
-    _.z    = 1.0
-    _.size = 0.5
-    _.fg   = color_white
     _.glyph = ui_sprite(ui_stamina_heart) // 💛
 
-let player_template = templates.define(ent_body | ent_visible | ent_mind | ent_input | ent_debug):
-    _.name  = "player"
+let char_template = templates.define(ent_body | ent_visible | ent_mind):
+    _.name  = "UNKNOWN character"
     _.glyph = avatar_sprite(avatar_content) // 🙂
     _.fg    = color_white
     _.z     = 1.0
     _.size  = 1.0
     _.cap   = xy_f { 3, 3 }
-    _.initiative = 10
-
     _.add_child(entrel_body, xy_f { 0, 2 }, templates.defs[left_hand_template])
     _.add_child(entrel_body, xy_f { 2, 2 }, templates.defs[right_hand_template])
+
+let player_template = templates.extend(char_template):
+    _.type |= ent_input | ent_debug
+    _.name  = "player"
+    _.initiative = 10
 
     // TODO would it be better to have a heart-container?
     let off = xy_f { -0.25, -0.25 }
@@ -705,81 +701,57 @@ let gift_air = templates.define(ent_body | ent_visible):
     _.glyph = item_sprite(item_wind)
     _.fg    = color_cyan
 
-let element_earth = templates.define(ent_body | ent_visible | ent_mind):
-    _.name  = "earth elemental"
-    _.glyph = item_sprite(item_clover)
-    _.fg    = color_dark_green
-    _.z     = 1.0
-    _.size  = 1.0
-    _.cap   = xy_f { 3, 3 }
-    _.initiative = 3
+let element_earth = templates.extend(char_template) e:
+    let gift = templates.defs[gift_earth]
+    e.name  = "earth elemental"
+    e.glyph = item_sprite(item_clover)
+    e.fg    = color_dark_green
+    e.initiative = 3
+    e.children[0] = e.children[0].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
+    e.children[1] = e.children[1].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
 
-    let left_hand  = templates.defs[left_hand_template].dupe()
-    let right_hand = templates.defs[right_hand_template].dupe()
-    let gift       = templates.defs[gift_earth]
-    left_hand.glyph = glyph_0
-    right_hand.glyph = glyph_0
-    left_hand.add_child(entrel_held, xy_0, gift)
-    right_hand.add_child(entrel_held, xy_0, gift)
-    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
-    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
+let element_water = templates.extend(char_template) e:
+    let gift = templates.defs[gift_water]
+    e.name  = "water elemental"
+    e.glyph = item_sprite(item_water)
+    e.fg    = color_teal
+    e.initiative = 4
+    e.children[0] = e.children[0].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
+    e.children[1] = e.children[1].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
 
-let element_water = templates.define(ent_body | ent_visible | ent_mind):
-    _.name  = "water elemental"
-    _.glyph = item_sprite(item_water)
-    _.fg    = color_teal
-    _.z     = 1.0
-    _.size  = 1.0
-    _.cap   = xy_f { 3, 3 }
-    _.initiative = 4
+let element_fire = templates.extend(char_template) e:
+    let gift = templates.defs[gift_fire]
+    e.name  = "fire elemental"
+    e.glyph = item_sprite(item_fire)
+    e.fg    = color_orange
+    e.initiative = 5
+    e.children[0] = e.children[0].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
+    e.children[1] = e.children[1].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
 
-    let left_hand  = templates.defs[left_hand_template].dupe()
-    let right_hand = templates.defs[right_hand_template].dupe()
-    let gift       = templates.defs[gift_water]
-    left_hand.glyph = glyph_0
-    right_hand.glyph = glyph_0
-    left_hand.add_child(entrel_held, xy_0, gift)
-    right_hand.add_child(entrel_held, xy_0, gift)
-    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
-    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
-
-let element_fire = templates.define(ent_body | ent_visible | ent_mind):
-    _.name  = "fire elemental"
-    _.glyph = item_sprite(item_fire)
-    _.fg    = color_orange
-    _.z     = 1.0
-    _.size  = 1.0
-    _.cap   = xy_f { 3, 3 }
-    _.initiative = 5
-
-    let left_hand  = templates.defs[left_hand_template].dupe()
-    let right_hand = templates.defs[right_hand_template].dupe()
-    let gift       = templates.defs[gift_fire]
-    left_hand.glyph = glyph_0
-    right_hand.glyph = glyph_0
-    left_hand.add_child(entrel_held, xy_0, gift)
-    right_hand.add_child(entrel_held, xy_0, gift)
-    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
-    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
-
-let element_air = templates.define(ent_body | ent_visible | ent_mind):
-    _.name  = "air elemental"
-    _.glyph = item_sprite(item_wind)
-    _.fg    = color_cyan
-    _.z     = 1.0
-    _.size  = 1.0
-    _.cap   = xy_f { 3, 3 }
-    _.initiative = 6
-
-    let left_hand  = templates.defs[left_hand_template].dupe()
-    let right_hand = templates.defs[right_hand_template].dupe()
-    let gift       = templates.defs[gift_air]
-    left_hand.glyph = glyph_0
-    right_hand.glyph = glyph_0
-    left_hand.add_child(entrel_held, xy_0, gift)
-    right_hand.add_child(entrel_held, xy_0, gift)
-    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand)
-    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand)
+let element_air = templates.extend(char_template) e:
+    let gift = templates.defs[gift_air]
+    e.name  = "air elemental"
+    e.glyph = item_sprite(item_wind)
+    e.fg    = color_cyan
+    e.initiative = 6
+    e.children[0] = e.children[0].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
+    e.children[1] = e.children[1].extend():
+        _.glyph = glyph_0 // TODO really we want an "invisible hand"
+        _.add_child(entrel_held, xy_0, gift)
 
 def build_world(chunk):
     let size = 12

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -757,9 +757,7 @@ let element_air = templates.extend(char_template) e:
 
 def build_world(chunk):
     let size = 12
-    let build = ent_scaffold {
-        templates : templates
-    }
+    let build = ent_scaffold {}
 
     let dirt = [
         glyph_0, glyph_0, uniblock(0x2591), // ░
@@ -777,7 +775,7 @@ def build_world(chunk):
     let tree_fg_base      = color { 0.2,  0.25, 0.1,  1 }
     let tree_fg_variance  = color { 0,    0.5,  0,    0 }
 
-    build.use_id(floor_template):
+    build.use(templates.defs[floor_template]):
         build.fill_rect(size) x, y:
             build.create_with(chunk) id:
                 let glyph = dirt.rnd_pick()
@@ -785,7 +783,7 @@ def build_world(chunk):
                 let fg = if glyph == glyph_0: color_clear else: bg + floor_fg_lift
                 chunk.ren[id] = render { bg, fg, glyph }
             if x == 0 || y == 0 || x == size-1 || y == size-1:
-                build.use_id(trees.rnd_pick()): build.create_with(chunk) id:
+                build.use(templates.defs[trees.rnd_pick()]): build.create_with(chunk) id:
                     chunk.ren[id] = chunk.ren[id].with_fg(tree_fg_base + tree_fg_variance * rnd_float())
 
     let mid = float(floor(size / 2))
@@ -796,8 +794,8 @@ def build_world(chunk):
             xy_f {  l,  l },
             xy_f {  l, -l },
             xy_f { -l, -l },
-        ]): build.use_id(elements[_]): build.create(chunk)
-        build.use_id(player_template): build.create(chunk)
+        ]): build.use(templates.defs[elements[_]]): build.create(chunk)
+        build.use(templates.defs[player_template]): build.create(chunk)
 
 //// usage
 

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -56,9 +56,6 @@ def print_list(title, level, body):
     else: if last != "":
         print(indent + "- " + last)
 
-// TODO eject data templates into separate module
-let templates = ent_templates {}
-
 class timers:
     labels = []::string
     values = []::[float]
@@ -582,29 +579,26 @@ def unicode(code:int):  return glyph { unicode_glyph_mode,  font_rune(unicode_gl
 def uniblock(code:int): return glyph { uniblock_glyph_mode, font_rune(uniblock_glyph_mode, code) }
 def twemoji(code:int):  return glyph { twemoji_glyph_mode,  font_rune(twemoji_glyph_mode,  code) }
 
-let floor_template = templates.define(ent_cell | ent_visible):
+let floor_template = new_template(ent_cell | ent_visible):
     _.z    = 0.0
     _.size = 1.0
 
-// FIXME tmpl_ prefix to avoid sheet constants ; ideally sheet should own these
-// definitions
-
-let tmpl_item_pine_apple = templates.define(ent_body | ent_visible):
+let pine_apple_template = new_template(ent_body | ent_visible):
     _.name = "pineapple"
     _.z    = 0.75
     _.size = 1.0
     _.fg   = color_white
     _.glyph = item_sprite(item_pine_apple)
 
-let tmpl_item_apple = templates.define(ent_body | ent_visible):
+let apple_template = new_template(ent_body | ent_visible):
     _.name = "apple"
     _.z    = 0.75
     _.size = 1.0
     _.fg   = color_white
     _.glyph = item_sprite(item_apple)
 
-let tree_evergreen = templates.define(ent_body | ent_visible | ent_holds):
-    let fruit = templates.defs[tmpl_item_pine_apple]
+let tree_evergreen = new_template(ent_body | ent_visible | ent_holds):
+    let fruit = pine_apple_template
     _.name = "evergreen tree"
     _.z    = 0.5
     _.size = 1.0
@@ -615,8 +609,8 @@ let tree_evergreen = templates.define(ent_body | ent_visible | ent_holds):
     _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 1 })
     _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
 
-let tree_deciduous = templates.define(ent_body | ent_visible | ent_holds):
-    let fruit = templates.defs[tmpl_item_apple]
+let tree_deciduous = new_template(ent_body | ent_visible | ent_holds):
+    let fruit = apple_template
     _.name = "deciduous tree"
     _.z    = 0.5
     _.size = 1.0
@@ -630,7 +624,7 @@ let tree_deciduous = templates.define(ent_body | ent_visible | ent_holds):
     _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 3 })
     _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 3 })
 
-let left_hand_template = templates.define(ent_body | ent_visible | ent_holds | ent_acts):
+let left_hand_template = new_template(ent_body | ent_visible | ent_holds | ent_acts):
     _.name = "left hand"
     _.z    = 1.0
     _.size = 1.0
@@ -638,122 +632,117 @@ let left_hand_template = templates.define(ent_body | ent_visible | ent_holds | e
     _.glyph = ui_sprite(ui_left_hand)
     _.cap = xy_f { 1, 1 }
 
-let right_hand_template = templates.extend(left_hand_template):
+let right_hand_template = left_hand_template.extend():
     _.name = "right hand"
     _.glyph = ui_sprite(ui_right_hand)
 
-let heart_template = templates.define(ent_body | ent_visible):
+let heart_template = new_template(ent_body | ent_visible):
     _.name = "heart"
     _.z    = 1.0
     _.size = 0.5
     _.fg   = color_white
     _.glyph = ui_sprite(ui_health_heart) // ❤️
 
-let stamina_heart_template = templates.extend(heart_template):
+let stamina_heart_template = heart_template.extend():
     _.name = "stamheart"
     _.glyph = ui_sprite(ui_stamina_heart) // 💛
 
-let char_template = templates.define(ent_body | ent_visible | ent_mind):
+let char_template = new_template(ent_body | ent_visible | ent_mind):
     _.name  = "UNKNOWN character"
     _.glyph = avatar_sprite(avatar_content) // 🙂
     _.fg    = color_white
     _.z     = 1.0
     _.size  = 1.0
     _.cap   = xy_f { 3, 3 }
-    _.add_child(entrel_body, xy_f { 0, 2 }, templates.defs[left_hand_template])
-    _.add_child(entrel_body, xy_f { 2, 2 }, templates.defs[right_hand_template])
+    _.add_child(entrel_body, xy_f { 0, 2 }, left_hand_template)
+    _.add_child(entrel_body, xy_f { 2, 2 }, right_hand_template)
 
-let player_template = templates.extend(char_template):
+let player_template = char_template.extend():
     _.type |= ent_input | ent_debug
     _.name  = "player"
     _.initiative = 10
 
     // TODO would it be better to have a heart-container?
     let off = xy_f { -0.25, -0.25 }
-    let heart = templates.defs[heart_template]
-    _.add_child(entrel_body, xy_f { 0.0, 0 } + off, heart)
-    _.add_child(entrel_body, xy_f { 0.5, 0 } + off, heart)
-    _.add_child(entrel_body, xy_f { 1.0, 0 } + off, heart)
+    _.add_child(entrel_body, xy_f { 0.0, 0 } + off, heart_template)
+    _.add_child(entrel_body, xy_f { 0.5, 0 } + off, heart_template)
+    _.add_child(entrel_body, xy_f { 1.0, 0 } + off, heart_template)
 
-let gift_earth = templates.define(ent_body | ent_visible):
+let gift_earth = new_template(ent_body | ent_visible):
     _.name = "gift of earth"
     _.z     = 0.75
     _.size  = 1.0
     _.glyph = item_sprite(item_clover)
     _.fg    = color_dark_green
 
-let gift_water = templates.define(ent_body | ent_visible):
+let gift_water = new_template(ent_body | ent_visible):
     _.name = "gift of water"
     _.z     = 0.75
     _.size  = 1.0
     _.glyph = item_sprite(item_water)
     _.fg    = color_teal
 
-let gift_fire = templates.define(ent_body | ent_visible):
+let gift_fire = new_template(ent_body | ent_visible):
     _.name = "gift of fire"
     _.z     = 0.75
     _.size  = 1.0
     _.glyph = item_sprite(item_fire)
     _.fg    = color_orange
 
-let gift_air = templates.define(ent_body | ent_visible):
+let gift_air = new_template(ent_body | ent_visible):
     _.name = "gift of air"
     _.z     = 0.75
     _.size  = 1.0
     _.glyph = item_sprite(item_wind)
     _.fg    = color_cyan
 
-let element_earth = templates.extend(char_template) e:
-    let gift = templates.defs[gift_earth]
+let element_earth = char_template.extend() e:
     e.name  = "earth elemental"
     e.glyph = item_sprite(item_clover)
     e.fg    = color_dark_green
     e.initiative = 3
     e.children[0] = e.children[0].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_earth)
     e.children[1] = e.children[1].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_earth)
 
-let element_water = templates.extend(char_template) e:
-    let gift = templates.defs[gift_water]
+let element_water = char_template.extend() e:
     e.name  = "water elemental"
     e.glyph = item_sprite(item_water)
     e.fg    = color_teal
     e.initiative = 4
     e.children[0] = e.children[0].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_water)
     e.children[1] = e.children[1].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_water)
 
-let element_fire = templates.extend(char_template) e:
-    let gift = templates.defs[gift_fire]
+let element_fire = char_template.extend() e:
     e.name  = "fire elemental"
     e.glyph = item_sprite(item_fire)
     e.fg    = color_orange
     e.initiative = 5
     e.children[0] = e.children[0].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_fire)
     e.children[1] = e.children[1].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_fire)
 
-let element_air = templates.extend(char_template) e:
-    let gift = templates.defs[gift_air]
+let element_air = char_template.extend() e:
     e.name  = "air elemental"
     e.glyph = item_sprite(item_wind)
     e.fg    = color_cyan
     e.initiative = 6
     e.children[0] = e.children[0].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_air)
     e.children[1] = e.children[1].extend():
         _.glyph = glyph_0 // TODO really we want an "invisible hand"
-        _.add_child(entrel_held, xy_0, gift)
+        _.add_child(entrel_held, xy_0, gift_air)
 
 def build_world(chunk):
     let size = 12
@@ -775,7 +764,7 @@ def build_world(chunk):
     let tree_fg_base      = color { 0.2,  0.25, 0.1,  1 }
     let tree_fg_variance  = color { 0,    0.5,  0,    0 }
 
-    build.use(templates.defs[floor_template]):
+    build.use(floor_template):
         build.fill_rect(size) x, y:
             build.create_with(chunk) id:
                 let glyph = dirt.rnd_pick()
@@ -783,7 +772,7 @@ def build_world(chunk):
                 let fg = if glyph == glyph_0: color_clear else: bg + floor_fg_lift
                 chunk.ren[id] = render { bg, fg, glyph }
             if x == 0 || y == 0 || x == size-1 || y == size-1:
-                build.use(templates.defs[trees.rnd_pick()]): build.create_with(chunk) id:
+                build.use(trees.rnd_pick()): build.create_with(chunk) id:
                     chunk.ren[id] = chunk.ren[id].with_fg(tree_fg_base + tree_fg_variance * rnd_float())
 
     let mid = float(floor(size / 2))
@@ -794,8 +783,8 @@ def build_world(chunk):
             xy_f {  l,  l },
             xy_f {  l, -l },
             xy_f { -l, -l },
-        ]): build.use(templates.defs[elements[_]]): build.create(chunk)
-        build.use(templates.defs[player_template]): build.create(chunk)
+        ]): build.use(elements[_]): build.create(chunk)
+        build.use(player_template): build.create(chunk)
 
 //// usage
 

--- a/src/game.lobster
+++ b/src/game.lobster
@@ -486,7 +486,7 @@ class stacked_scene : system
 def build_entity(this::ent_scaffold, chunk:chunk, id:int):
     if tmpl.type & ent_mind:
         chunk.minds.set_init(id, tmpl.initiative)
-    if tmpl.spawn_template.length:
+    if tmpl.spawn.length:
         chunk.spawner.add_spawns(id, this)
 
 def create_with(this::ent_scaffold, chunk:chunk, body):
@@ -604,29 +604,31 @@ let tmpl_item_apple = templates.define(ent_body | ent_visible):
     _.glyph = item_sprite(item_apple)
 
 let tree_evergreen = templates.define(ent_body | ent_visible | ent_holds):
+    let fruit = templates.defs[tmpl_item_pine_apple]
     _.name = "evergreen tree"
     _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
     _.glyph = tile_sprite(tile_pine_tree)
     _.cap = xy_f { 3, 4 }
-    _.add_spawn_child(tmpl_item_pine_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 0 })
-    _.add_spawn_child(tmpl_item_pine_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 1 })
-    _.add_spawn_child(tmpl_item_pine_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 0 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 1 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
 
 let tree_deciduous = templates.define(ent_body | ent_visible | ent_holds):
+    let fruit = templates.defs[tmpl_item_apple]
     _.name = "deciduous tree"
     _.z    = 0.5
     _.size = 1.0
     _.fg   = color_white
     _.glyph = tile_sprite(tile_apple_tree)
     _.cap = xy_f { 6, 6 }
-    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
-    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 2 })
-    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 2 })
-    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 4, 2 })
-    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 3 })
-    _.add_spawn_child(tmpl_item_apple, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 3 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 1, 2 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 2 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 2 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 4, 2 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 2, 3 })
+    _.add_spawn_child(fruit, xy_i { 5, 1000 }, entrel_held, xy_f { 3, 3 })
 
 let left_hand_template = templates.define(ent_body | ent_visible | ent_holds | ent_acts):
     _.name = "left hand"


### PR DESCRIPTION
As I've gotten more and more used to working with the newly iterated `ent_template` and `ent_scaffold` system, the "definition database" that was `ent_templates` felt more and more redundant.

The last hold out was the spawn system holding onto a weak template reference ( id in a database eventually provided by the scaffold ).

On balance this seems way simpler to me, so let's prove if we need a container going forward.